### PR TITLE
enable deleting verbs

### DIFF
--- a/src/admin/store/reducers/gameStateReducer/worldStateReducer/entitiesReducer.ts
+++ b/src/admin/store/reducers/gameStateReducer/worldStateReducer/entitiesReducer.ts
@@ -116,7 +116,7 @@ export const entitiesSlice = createSlice({
         ...state[id].verbs,
         [verbIndex]: verbLogics,
       };
-      if(!verbLogics) {
+      if (!verbLogics) {
         delete newVerbs[verbIndex];
       }
       state[id].verbs = newVerbs;

--- a/src/admin/store/reducers/gameStateReducer/worldStateReducer/entitiesReducer.ts
+++ b/src/admin/store/reducers/gameStateReducer/worldStateReducer/entitiesReducer.ts
@@ -31,7 +31,7 @@ type SizeWithId = {
 type EntityVerb = {
   id: number;
   verbIndex: VerbIndex;
-  verbLogics: VerbLogic[];
+  verbLogics?: VerbLogic[];
 };
 
 type DeleteInfo = {
@@ -116,6 +116,9 @@ export const entitiesSlice = createSlice({
         ...state[id].verbs,
         [verbIndex]: verbLogics,
       };
+      if(!verbLogics) {
+        delete newVerbs[verbIndex];
+      }
       state[id].verbs = newVerbs;
     },
     setEntity: (state, action: PayloadAction<EntityWithId>) => {

--- a/src/admin/ui/verbs/VerbList.tsx
+++ b/src/admin/ui/verbs/VerbList.tsx
@@ -1,16 +1,17 @@
 import React from 'react';
 import { VerbIndex, VerbLogic } from 'game/store/types';
 import {
-  Accordion, AccordionDetails, AccordionSummary, Box, Button, Typography,
+  Accordion, AccordionDetails, AccordionSummary, Box, Button, IconButton, Typography,
 } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import DeleteIcon from '@mui/icons-material/Delete';
 import Verb from './Verb';
 
 type Props = {
   verbIndex: VerbIndex;
   verbLogics: VerbLogic[];
   verbName: string;
-  handleChange: (verbIndex: VerbIndex, verbLogics: VerbLogic[]) => void;
+  handleChange: (verbIndex: VerbIndex, verbLogics?: VerbLogic[]) => void;
 };
 const VerbList = ({
   verbIndex, verbLogics, handleChange, verbName,
@@ -52,6 +53,11 @@ const VerbList = ({
           <Button onClick={onCreate}>
             Add Logic
           </Button>
+          <IconButton 
+            onClick={() => handleChange(verbIndex)}
+          >
+            <DeleteIcon />
+          </IconButton>
         </Box>
       </AccordionDetails>
     </Accordion>

--- a/src/admin/ui/verbs/VerbList.tsx
+++ b/src/admin/ui/verbs/VerbList.tsx
@@ -53,7 +53,7 @@ const VerbList = ({
           <Button onClick={onCreate}>
             Add Logic
           </Button>
-          <IconButton 
+          <IconButton
             onClick={() => handleChange(verbIndex)}
           >
             <DeleteIcon />

--- a/src/admin/ui/verbs/index.tsx
+++ b/src/admin/ui/verbs/index.tsx
@@ -16,7 +16,7 @@ const Verbs = ({ entity }: Props) => {
   const dispatch = useDispatch();
   const verbNames = useSelector(state => state.gameState.verbNames);
 
-  const handleChange = (verbIndex: VerbIndex, verbLogics: VerbLogic[]) => {
+  const handleChange = (verbIndex: VerbIndex, verbLogics?: VerbLogic[]) => {
     dispatch(setEntityVerb({
       id: entity.id,
       verbIndex,


### PR DESCRIPTION
Enabled deleting verbs by making verbLogics an optional property for now and using that to delete withing `setEntityVerb.` To be later replaced with a "deleteEntityVerb" reducer.