### PR TITLE
Add tooltips

### DIFF
--- a/src/admin/store/reducers/editorStateReducer/index.ts
+++ b/src/admin/store/reducers/editorStateReducer/index.ts
@@ -2,9 +2,11 @@ import { combineReducers } from 'redux';
 import selectedEntityReducer from './selectedEntityReducer';
 import sceneryEditingReducer from './sceneryEditingReducer';
 import uploadStateReducer from './uploadStateReducer';
+import tooltipsReducer from './tooltipsReducer';
 
 export default combineReducers({
   selectedEntity: selectedEntityReducer,
   sceneryEditing: sceneryEditingReducer,
   uploadState: uploadStateReducer,
+  tooltips: tooltipsReducer,
 });

--- a/src/admin/store/reducers/editorStateReducer/tooltipsReducer.ts
+++ b/src/admin/store/reducers/editorStateReducer/tooltipsReducer.ts
@@ -1,0 +1,29 @@
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+
+const storageKey = 'point-click-tooltips';
+
+export const setTooltipEnabled = createAsyncThunk(
+  'tooltips/enabled',
+  async (enabled: boolean) => {
+    const value = enabled ? '1' : '0';
+    localStorage.setItem(storageKey, value);
+    return enabled;
+  },
+);
+
+export const tooltipsSlice = createSlice({
+  name: 'tooltips',
+  initialState: () => {
+    const stringValue = localStorage.getItem(storageKey);
+    if (!stringValue) {
+      return true;
+    }
+    return stringValue === '1';
+  },
+  reducers: {},
+  extraReducers: builder => {
+    builder.addCase(setTooltipEnabled.fulfilled, (state, action) => action.payload);
+  },
+});
+
+export default tooltipsSlice.reducer;

--- a/src/admin/ui/rooms/DoorDetails.tsx
+++ b/src/admin/ui/rooms/DoorDetails.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import Grid from '@mui/material/Grid';
-import FormControlLabel from '@mui/material/FormControlLabel';
-import Switch from '@mui/material/Switch';
 import Typography from '@mui/material/Typography';
 import { Door, DoorDir, DoorState } from 'game/store/types';
 import { setDoor } from 'admin/store/reducers/gameStateReducer/worldStateReducer/doorsReducer';
@@ -11,6 +9,7 @@ import useStyles from '../shared/useStyles';
 import ImgSelector from '../shared/assets/ImgSelector';
 import Selector, { makeOptions } from '../shared/Selector';
 import MapPositioner from './MapPositioner';
+import Toggle from '../shared/Toggle';
 
 type Props = {
   door: Door;
@@ -45,6 +44,7 @@ const DoorDetails = ({ door }: Props) => {
           label="closedText"
           value={door.closedText}
           onChange={handleChange('closedText')}
+          tooltip="Custom text to display when the player examines the doors and it is in a CLOSED state"
         />
       </Grid>
       <Grid item xs={12}>
@@ -52,6 +52,7 @@ const DoorDetails = ({ door }: Props) => {
           label="openText"
           value={door.openText}
           onChange={handleChange('openText')}
+          tooltip="Custom text to display when the player opens the door"
         />
       </Grid>
       <Grid item xs={12}>
@@ -59,6 +60,7 @@ const DoorDetails = ({ door }: Props) => {
           label="lockedText"
           value={door.lockedText}
           onChange={handleChange('lockedText')}
+          tooltip="Custom text to display when the player examines the doors and it is in a LOCKED state"
         />
       </Grid>
       <Grid item xs={12}>
@@ -66,6 +68,7 @@ const DoorDetails = ({ door }: Props) => {
           label="unlockText"
           value={door.unlockText}
           onChange={handleChange('unlockText')}
+          tooltip="Custom text to display when the player unlocks the door"
         />
       </Grid>
       <Grid item xs={12}>
@@ -73,17 +76,15 @@ const DoorDetails = ({ door }: Props) => {
           label="description"
           value={door.description}
           onChange={handleChange('description')}
+          tooltip="Default text to display when examining the door in any state"
         />
       </Grid>
       <Grid item xs={12}>
-        <FormControlLabel
-          control={(
-            <Switch
-              checked={!!door.hidden}
-              onChange={e => handleChange('hidden')(e.currentTarget.checked)}
-            />
-          )}
+        <Toggle
+          value={!!door.hidden}
+          onChange={handleChange('hidden')}
           label="hidden?"
+          tooltip="If true, the door is hidden from the minimap until the player opens it via the viewport"
         />
       </Grid>
       <Grid item xs={12}>
@@ -92,6 +93,7 @@ const DoorDetails = ({ door }: Props) => {
           value={door.dest}
           onChange={val => handleChange('dest')(parseInt(val, 10))}
           options={makeOptions(allRoomIds)}
+          tooltip="The ID of the room this door leads to"
         />
       </Grid>
       <Grid item xs={12}>
@@ -100,6 +102,7 @@ const DoorDetails = ({ door }: Props) => {
           value={door.keyId}
           onChange={id => handleChange('keyId')(parseInt(id, 10))}
           options={makeOptions(allKeyIds)}
+          tooltip="The ID of the item the player must be USING to unlock the door"
         />
       </Grid>
       <Grid item xs={12}>
@@ -112,10 +115,11 @@ const DoorDetails = ({ door }: Props) => {
       </Grid>
       <Grid item xs={12}>
         <Selector
-          label="animation direction"
+          label="transition"
           value={door.dir}
           onChange={handleChange('dir')}
           options={makeOptions(Object.keys(DoorDir))}
+          tooltip="The predefined animation that runs when transition to the next room through this door"
         />
       </Grid>
       <Grid item xs={12}>
@@ -123,6 +127,7 @@ const DoorDetails = ({ door }: Props) => {
           label="closedImg"
           value={door.closedImg}
           onChange={handleChange('closedImg')}
+          tooltip="Image to display when the door is in a CLOSED state. If non specified, display whatever is in the background"
         />
       </Grid>
       <Grid item xs={12}>
@@ -130,6 +135,7 @@ const DoorDetails = ({ door }: Props) => {
           label="openImg"
           value={door.openImg}
           onChange={handleChange('openImg')}
+          tooltip="Image to display when the door is in an OPEN state. If non specified, display whatever is in the background"
         />
       </Grid>
       <Grid item xs={12}>
@@ -137,11 +143,12 @@ const DoorDetails = ({ door }: Props) => {
           label="open condition"
           value={door.openCondition}
           onChange={handleChange('openCondition')}
+          tooltip="Custom flag to determine if player can open this door (even if the door is in an OPEN state)"
         />
       </Grid>
       <Grid item xs={12}>
         <MapPositioner
-          label="Select Map Position"
+          label="Select Minimap Position"
           value={door.mapPosition}
           onChange={handleChange('mapPosition')}
         />

--- a/src/admin/ui/rooms/ItemDetails.tsx
+++ b/src/admin/ui/rooms/ItemDetails.tsx
@@ -49,6 +49,7 @@ const ItemDetails = ({ item }: Props) => {
           label="description"
           value={item.description}
           onChange={handleChange('description')}
+          tooltip="Displays when 'LOOK's at this item within their inventory"
         />
       </Grid>
       <Grid item xs={12}>

--- a/src/admin/ui/rooms/ItemDetails.tsx
+++ b/src/admin/ui/rooms/ItemDetails.tsx
@@ -41,6 +41,7 @@ const ItemDetails = ({ item }: Props) => {
           label="name"
           value={item.name}
           onChange={handleChange('name')}
+          tooltip="How the item displays in the player's inventory"
         />
       </Grid>
       <Grid item xs={12}>

--- a/src/admin/ui/rooms/ItemDetails.tsx
+++ b/src/admin/ui/rooms/ItemDetails.tsx
@@ -3,12 +3,12 @@ import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
 import { setEntity } from 'admin/store/reducers/gameStateReducer/worldStateReducer/entitiesReducer';
 import { Item } from 'game/store/types';
-import { FormControlLabel, Switch } from '@mui/material';
 import { useDispatch } from '../hooks/redux';
 import LongTextField from '../shared/LongTextField';
 import useStyles from '../shared/useStyles';
 import ImgSelector from '../shared/assets/ImgSelector';
 import Verbs from '../verbs';
+import Toggle from '../shared/Toggle';
 
 type Props = {
   item: Item;
@@ -81,14 +81,11 @@ const ItemDetails = ({ item }: Props) => {
         />
       </Grid>
       <Grid item xs={12}>
-        <FormControlLabel
-          control={(
-            <Switch
-              checked={!!item.requiresPrecision}
-              onChange={e => handleChange('requiresPrecision')(e.currentTarget.checked)}
-            />
-          )}
+        <Toggle
+          value={!!item.requiresPrecision}
+          onChange={handleChange('requiresPrecision')}
           label="require direct click?"
+          tooltip="If true, only opaque parts of the image rectangle are clickable"
         />
       </Grid>
       <Verbs entity={item} />

--- a/src/admin/ui/rooms/ItemDetails.tsx
+++ b/src/admin/ui/rooms/ItemDetails.tsx
@@ -64,6 +64,7 @@ const ItemDetails = ({ item }: Props) => {
           label="on take"
           value={item.onTake}
           onChange={handleChange('onTake')}
+          tooltip="Custom text to display when user collects this item"
         />
       </Grid>
       <Grid item xs={12}>
@@ -71,6 +72,7 @@ const ItemDetails = ({ item }: Props) => {
           label="takeable flag"
           value={item.takeableFlag}
           onChange={handleChange('takeableFlag')}
+          tooltip="When set, this flag must be on for the player to collect this item (otherwise, the item is takeable by default)"
         />
       </Grid>
       <Grid item xs={12}>
@@ -78,6 +80,7 @@ const ItemDetails = ({ item }: Props) => {
           label="visible flag"
           value={item.visibleFlag}
           onChange={handleChange('visibleFlag')}
+          tooltip="When set, this flag must be on for this item to be visible (otherwise, the item is visible by default)"
         />
       </Grid>
       <Grid item xs={12}>

--- a/src/admin/ui/rooms/RoomDetails.tsx
+++ b/src/admin/ui/rooms/RoomDetails.tsx
@@ -8,7 +8,6 @@ import { useParams, Link } from 'react-router-dom';
 import ArrowBack from '@mui/icons-material/ArrowBack';
 import { setRoom } from 'admin/store/reducers/gameStateReducer/worldStateReducer/roomsReducer';
 import { Room } from 'game/store/types';
-import { FormControlLabel, Switch } from '@mui/material';
 import { useDispatch } from '../hooks/redux';
 import LongTextField from '../shared/LongTextField';
 import useStyles from '../shared/useStyles';
@@ -18,6 +17,7 @@ import PreviewWidget from '../preview/PreviewWidget';
 import ImgSelector from '../shared/assets/ImgSelector';
 import AudioSelector from '../shared/assets/AudioSelector';
 import VideoSelector from '../shared/assets/VideoSelector';
+import Toggle from '../shared/Toggle';
 
 type Props = { room: Room; roomId: number };
 const RoomDetails = ({ room, roomId }: Props) => {
@@ -99,14 +99,11 @@ const RoomDetails = ({ room, roomId }: Props) => {
           />
         </Grid>
         <Grid item xs={12}>
-          <FormControlLabel
-            control={(
-              <Switch
-                checked={!!room.gameOver}
-                onChange={e => handleChange('gameOver')(e.currentTarget.checked)}
-              />
-          )}
-            label="Game Over Screen?"
+          <Toggle
+            value={!!room.gameOver}
+            onChange={handleChange('gameOver')}
+            label="game over screen?"
+            tooltip="If true, this room triggers the game over menu"
           />
         </Grid>
         <Grid item xs={12}>

--- a/src/admin/ui/rooms/RoomDetails.tsx
+++ b/src/admin/ui/rooms/RoomDetails.tsx
@@ -63,6 +63,7 @@ const RoomDetails = ({ room, roomId }: Props) => {
             label="initial description"
             value={room.initialDescription}
             onChange={handleChange('initialDescription')}
+            tooltip="Text to display just the first time the player enters this room"
           />
         </Grid>
         <Grid item xs={12}>
@@ -70,6 +71,7 @@ const RoomDetails = ({ room, roomId }: Props) => {
             label="description"
             value={room.description}
             onChange={handleChange('description')}
+            tooltip="Default text that displays upon entering this room"
           />
         </Grid>
         <Grid item xs={12}>
@@ -77,6 +79,7 @@ const RoomDetails = ({ room, roomId }: Props) => {
             label="bg img"
             value={room.img}
             onChange={handleChange('img')}
+            tooltip="Background image for this room"
           />
         </Grid>
         <Grid item xs={12}>
@@ -84,6 +87,7 @@ const RoomDetails = ({ room, roomId }: Props) => {
             label="bg video"
             value={room.video}
             onChange={handleChange('video')}
+            tooltip="Background video for this room. Takes precedence over bg img"
           />
         </Grid>
         <Grid item xs={12}>
@@ -91,6 +95,7 @@ const RoomDetails = ({ room, roomId }: Props) => {
             label="music"
             value={room.music}
             onChange={handleChange('music')}
+            tooltip="Background music to play upon entering the room"
           />
         </Grid>
         <Grid item xs={12}>

--- a/src/admin/ui/rooms/RoomDetails.tsx
+++ b/src/admin/ui/rooms/RoomDetails.tsx
@@ -18,6 +18,7 @@ import ImgSelector from '../shared/assets/ImgSelector';
 import AudioSelector from '../shared/assets/AudioSelector';
 import VideoSelector from '../shared/assets/VideoSelector';
 import Toggle from '../shared/Toggle';
+import TooltipToggle from './TooltipToggle';
 
 type Props = { room: Room; roomId: number };
 const RoomDetails = ({ room, roomId }: Props) => {
@@ -42,6 +43,7 @@ const RoomDetails = ({ room, roomId }: Props) => {
   return (
     <Box className={styles.leftColumn}>
       <Grid container>
+        <TooltipToggle />
         <Grid item xs={12}>
           <Link to={`/admin/${gameName}/rooms`}>
             <Button

--- a/src/admin/ui/rooms/SceneryDetails.tsx
+++ b/src/admin/ui/rooms/SceneryDetails.tsx
@@ -47,6 +47,7 @@ const SceneryDetails = ({ scenery }: Props) => {
           label="name"
           value={scenery.name}
           onChange={handleChange('name')}
+          tooltip="Convenience for editing. This name does not display in-game"
         />
       </Grid>
       <Grid item xs={12}>
@@ -54,6 +55,7 @@ const SceneryDetails = ({ scenery }: Props) => {
           label="description"
           value={scenery.description}
           onChange={handleChange('description')}
+          tooltip="Text that displays by default whn the player 'LOOK's at this scenery"
         />
       </Grid>
       <Grid item xs={12}>
@@ -61,6 +63,7 @@ const SceneryDetails = ({ scenery }: Props) => {
           label="open text"
           value={scenery.openText}
           onChange={handleChange('openText')}
+          tooltip="Custom text to display when the scenery is opened. Only relevant if the scenery contains items"
         />
       </Grid>
       <Grid item xs={12}>
@@ -68,6 +71,7 @@ const SceneryDetails = ({ scenery }: Props) => {
           label="moved text"
           value={scenery.movedText}
           onChange={handleChange('movedText')}
+          tooltip="Custom text to display after animation has completed"
         />
       </Grid>
       <Grid item xs={12}>
@@ -89,6 +93,7 @@ const SceneryDetails = ({ scenery }: Props) => {
           value={scenery.trigger}
           onChange={handleChange('trigger')}
           options={verbNames.map((verb, index) => ({ value: index, label: verb.name }))}
+          tooltip="Which verb causes this scenery to animate"
         />
       </Grid>
       <Grid item xs={12}>
@@ -103,6 +108,7 @@ const SceneryDetails = ({ scenery }: Props) => {
           label="visible flag"
           value={scenery.visibleFlag}
           onChange={handleChange('visibleFlag')}
+          tooltip="When set, this flag must be on for this scenery to be visible (otherwise, the item is visible by default)"
         />
       </Grid>
       <Contains container={scenery} />

--- a/src/admin/ui/rooms/SceneryDetails.tsx
+++ b/src/admin/ui/rooms/SceneryDetails.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
-import FormControlLabel from '@mui/material/FormControlLabel';
-import Switch from '@mui/material/Switch';
 import { setEntity } from 'admin/store/reducers/gameStateReducer/worldStateReducer/entitiesReducer';
 import { Nullable, Scenery } from 'game/store/types';
 import { setSceneryEditing } from 'admin/store/reducers/editorStateReducer/sceneryEditingReducer';
@@ -13,6 +11,7 @@ import ImgSelector from '../shared/assets/ImgSelector';
 import Selector from '../shared/Selector';
 import Verbs from '../verbs';
 import Contains from './Contains';
+import Toggle from '../shared/Toggle';
 
 type Props = {
   scenery: Scenery;
@@ -72,20 +71,16 @@ const SceneryDetails = ({ scenery }: Props) => {
         />
       </Grid>
       <Grid item xs={12}>
-        <FormControlLabel
-          control={(
-            <Switch
-              checked={positionEditing === 'endPosition'}
-              onChange={e => {
-                const position = e.currentTarget.checked ? 'endPosition' : 'startPosition';
-                dispatch(setSceneryEditing({
-                  position,
-                  id: scenery.id,
-                }));
-              }}
-            />
-          )}
+        <Toggle
+          value={positionEditing === 'endPosition'}
+          onChange={checked => {
+            dispatch(setSceneryEditing({
+              position: checked ? 'endPosition' : 'startPosition',
+              id: scenery.id,
+            }));
+          }}
           label={`Editing: ${positionEditing}`}
+          tooltip="For animated scenery, determines which part (start or end) of the animation position is currently being edited"
         />
       </Grid>
       <Grid item xs={12}>

--- a/src/admin/ui/rooms/TooltipToggle.tsx
+++ b/src/admin/ui/rooms/TooltipToggle.tsx
@@ -1,0 +1,20 @@
+import { setTooltipEnabled } from 'admin/store/reducers/editorStateReducer/tooltipsReducer';
+import React from 'react';
+import { useDispatch, useSelector } from '../hooks/redux';
+import Toggle from '../shared/Toggle';
+
+const TooltipToggle = () => {
+  const dispatch = useDispatch();
+  const tooltipsEnabled = useSelector(state => state.editorState.tooltips);
+
+  return (
+    <Toggle
+      value={tooltipsEnabled}
+      onChange={val => dispatch(setTooltipEnabled(val))}
+      label="enable tooltips"
+      tooltip="And this, my friend, is a tooltip toggle tooltip"
+    />
+  );
+};
+
+export default TooltipToggle;

--- a/src/admin/ui/shared/LongTextField.tsx
+++ b/src/admin/ui/shared/LongTextField.tsx
@@ -1,33 +1,65 @@
 import React from 'react';
 import TextField from '@mui/material/TextField';
+import Tooltip from '@mui/material/Tooltip';
+import Icon from '@mui/material/Icon';
+import Box from '@mui/material/Box';
 import { Nullable } from 'game/store/types';
+import Help from '@mui/icons-material/Help';
+import { makeStyles } from '@mui/styles';
+
+const useStyles = makeStyles({
+  tooltip: {
+    position: 'absolute',
+    top: '2px',
+    right: '10px',
+    cursor: 'pointer',
+    padding: '2px',
+    backgroundColor: 'white',
+  },
+  icon: {
+    height: '20px',
+  },
+});
 
 type Props = {
   label: string;
   value: Nullable<string>;
   onChange: (value: Nullable<string>) => void;
   fullWidth?: boolean;
+  tooltip?: string;
 };
 const LongTextField = ({
-  label, value, onChange, fullWidth = true,
+  label, value, onChange, fullWidth = true, tooltip,
 }: Props) => {
+  const classes = useStyles();
   return (
-    <TextField
-      label={label}
-      margin="normal"
-      multiline
-      fullWidth={fullWidth}
-      maxRows={6}
-      value={value || ''}
-      onChange={e => {
-        if (e.target.value === '') {
-          onChange(undefined);
-        } else {
-          onChange(e.target.value);
-        }
-      }}
-      variant="outlined"
-    />
+    <Box style={{ position: 'relative' }}>
+      <TextField
+        label={label}
+        margin="normal"
+        multiline
+        fullWidth={fullWidth}
+        maxRows={6}
+        value={value || ''}
+        onChange={e => {
+          if (e.target.value === '') {
+            onChange(undefined);
+          } else {
+            onChange(e.target.value);
+          }
+        }}
+        variant="outlined"
+      />
+      {tooltip && (
+        <Tooltip title={tooltip}>
+          <Box className={classes.tooltip}>
+            <Icon>
+              <Help fontSize="small" />
+            </Icon>
+          </Box>
+        </Tooltip>
+      )}
+    </Box>
   );
 };
 

--- a/src/admin/ui/shared/LongTextField.tsx
+++ b/src/admin/ui/shared/LongTextField.tsx
@@ -1,25 +1,7 @@
 import React from 'react';
 import TextField from '@mui/material/TextField';
-import Tooltip from '@mui/material/Tooltip';
-import Icon from '@mui/material/Icon';
-import Box from '@mui/material/Box';
 import { Nullable } from 'game/store/types';
-import Help from '@mui/icons-material/Help';
-import { makeStyles } from '@mui/styles';
-
-const useStyles = makeStyles({
-  tooltip: {
-    position: 'absolute',
-    top: '2px',
-    right: '10px',
-    cursor: 'pointer',
-    padding: '2px',
-    backgroundColor: 'white',
-  },
-  icon: {
-    height: '20px',
-  },
-});
+import WithTooltip from './WithTooltip';
 
 type Props = {
   label: string;
@@ -31,9 +13,8 @@ type Props = {
 const LongTextField = ({
   label, value, onChange, fullWidth = true, tooltip,
 }: Props) => {
-  const classes = useStyles();
   return (
-    <Box style={{ position: 'relative' }}>
+    <WithTooltip text={tooltip}>
       <TextField
         label={label}
         margin="normal"
@@ -50,16 +31,7 @@ const LongTextField = ({
         }}
         variant="outlined"
       />
-      {tooltip && (
-        <Tooltip title={tooltip}>
-          <Box className={classes.tooltip}>
-            <Icon>
-              <Help fontSize="small" />
-            </Icon>
-          </Box>
-        </Tooltip>
-      )}
-    </Box>
+    </WithTooltip>
   );
 };
 

--- a/src/admin/ui/shared/Selector.tsx
+++ b/src/admin/ui/shared/Selector.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import { Nullable } from 'game/store/types';
 import FormControl from '@mui/material/FormControl';
-import { InputLabel, MenuItem, Select } from '@mui/material';
+import {
+  Box, InputLabel, MenuItem, Select,
+} from '@mui/material';
+import WithTooltip from './WithTooltip';
 
 export const makeOptions = (options: string[]) => {
   return options.map(option => ({ value: option, label: option }));
@@ -18,31 +21,36 @@ type Props = {
   options: Option[];
   required?: boolean;
   style?: React.CSSProperties;
+  tooltip?: string;
 };
 const Selector = ({
-  label, value, onChange, options, required = false, style,
+  label, value, onChange, options, required = false, style, tooltip,
 }: Props) => {
   return (
-    <FormControl variant="outlined" style={{ minWidth: 120 }} margin="normal">
-      <InputLabel>{label}</InputLabel>
-      <Select
-        value={isEmpty(value) ? '' : value}
-        label={label}
-        onChange={e => {
-          if (e.target.value === '') {
-            onChange(undefined);
-          } else {
-            onChange(e.target.value);
-          }
-        }}
-        style={style}
-      >
-        {!required && <MenuItem value="" key=""><em>none</em></MenuItem>}
-        {options.map(option => (
-          <MenuItem value={option.value} key={option.value}>{option.label}</MenuItem>
-        ))}
-      </Select>
-    </FormControl>
+    <Box style={{ display: 'flex', flexDirection: 'row' }}>
+      <WithTooltip text={tooltip}>
+        <FormControl variant="outlined" style={{ minWidth: 120 }} margin="normal">
+          <InputLabel>{label}</InputLabel>
+          <Select
+            value={isEmpty(value) ? '' : value}
+            label={label}
+            onChange={e => {
+              if (e.target.value === '') {
+                onChange(undefined);
+              } else {
+                onChange(e.target.value);
+              }
+            }}
+            style={style}
+          >
+            {!required && <MenuItem value="" key=""><em>none</em></MenuItem>}
+            {options.map(option => (
+              <MenuItem value={option.value} key={option.value}>{option.label}</MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </WithTooltip>
+    </Box>
   );
 };
 

--- a/src/admin/ui/shared/Toggle.tsx
+++ b/src/admin/ui/shared/Toggle.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Box, FormControlLabel, Switch } from '@mui/material';
+import WithTooltip from './WithTooltip';
+
+type Props = {
+  label: string;
+  value: boolean;
+  onChange: (value: boolean) => void;
+  tooltip?: string;
+};
+const Toggle = ({
+  label, value, onChange, tooltip,
+}: Props) => {
+  return (
+    <Box style={{ float: 'left' }}>
+      <WithTooltip text={tooltip}>
+        <FormControlLabel
+          style={{ paddingRight: '20px', marginTop: '-1px' }}
+          control={(
+            <Switch
+              checked={value}
+              onChange={e => onChange(e.currentTarget.checked)}
+            />
+          )}
+          label={label}
+        />
+      </WithTooltip>
+    </Box>
+  );
+};
+
+export default Toggle;

--- a/src/admin/ui/shared/WithTooltip.tsx
+++ b/src/admin/ui/shared/WithTooltip.tsx
@@ -11,7 +11,6 @@ const useStyles = makeStyles({
     top: '2px',
     right: '10px',
     cursor: 'pointer',
-    padding: '2px',
     backgroundColor: 'white',
   },
 });
@@ -29,7 +28,7 @@ const WithTooltip = ({ text, children }: Props) => {
         <Tooltip title={text}>
           <Box className={classes.tooltip}>
             <Icon>
-              <Help fontSize="small" />
+              <Help sx={{ fontSize: 16 }} />
             </Icon>
           </Box>
         </Tooltip>

--- a/src/admin/ui/shared/WithTooltip.tsx
+++ b/src/admin/ui/shared/WithTooltip.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import Tooltip from '@mui/material/Tooltip';
+import Icon from '@mui/material/Icon';
+import Box from '@mui/material/Box';
+import Help from '@mui/icons-material/Help';
+import { makeStyles } from '@mui/styles';
+
+const useStyles = makeStyles({
+  tooltip: {
+    position: 'absolute',
+    top: '2px',
+    right: '10px',
+    cursor: 'pointer',
+    padding: '2px',
+    backgroundColor: 'white',
+  },
+});
+
+type Props = {
+  text?: string;
+  children: React.ReactNode;
+};
+const WithTooltip = ({ text, children }: Props) => {
+  const classes = useStyles();
+  return (
+    <Box style={{ position: 'relative' }}>
+      {children}
+      {text && (
+        <Tooltip title={text}>
+          <Box className={classes.tooltip}>
+            <Icon>
+              <Help fontSize="small" />
+            </Icon>
+          </Box>
+        </Tooltip>
+      )}
+    </Box>
+  );
+};
+
+export default WithTooltip;

--- a/src/admin/ui/shared/WithTooltip.tsx
+++ b/src/admin/ui/shared/WithTooltip.tsx
@@ -4,6 +4,7 @@ import Icon from '@mui/material/Icon';
 import Box from '@mui/material/Box';
 import Help from '@mui/icons-material/Help';
 import { makeStyles } from '@mui/styles';
+import { useSelector } from '../hooks/redux';
 
 const useStyles = makeStyles({
   tooltip: {
@@ -20,11 +21,13 @@ type Props = {
   children: React.ReactNode;
 };
 const WithTooltip = ({ text, children }: Props) => {
+  const tooltipsEnabled = useSelector(state => state.editorState.tooltips);
   const classes = useStyles();
+
   return (
     <Box style={{ position: 'relative' }}>
       {children}
-      {text && (
+      {tooltipsEnabled && text && (
         <Tooltip title={text}>
           <Box className={classes.tooltip}>
             <Icon>

--- a/src/admin/ui/shared/assets/AudioSelector.tsx
+++ b/src/admin/ui/shared/assets/AudioSelector.tsx
@@ -6,6 +6,7 @@ import getFilenames from 'shared/util/getFilenames';
 import { Stack } from '@mui/material';
 import Selector, { makeOptions } from '../Selector';
 import AudioUploader from './AudioUploader';
+import WithTooltip from '../WithTooltip';
 
 const loadAudios = async (gameName: string) => {
   const s3 = new S3(`${gameName}/audio`);
@@ -18,8 +19,11 @@ type Props = {
   label: string;
   value: Nullable<string>;
   onChange: (value: string) => void;
+  tooltip?: string;
 };
-const AudioSelector = ({ label, value, onChange }: Props) => {
+const AudioSelector = ({
+  label, value, onChange, tooltip,
+}: Props) => {
   const { gameName } = useParams<{ gameName: string }>();
   const [options, setOptions] = useState<Nullable<string[]>>(null);
 
@@ -38,12 +42,14 @@ const AudioSelector = ({ label, value, onChange }: Props) => {
 
   return (
     <Stack direction="row" spacing={2}>
-      <Selector
-        label={label}
-        value={options.length ? (value || '') : ''}
-        onChange={onChange}
-        options={makeOptions(options)}
-      />
+      <WithTooltip text={tooltip}>
+        <Selector
+          label={label}
+          value={options.length ? (value || '') : ''}
+          onChange={onChange}
+          options={makeOptions(options)}
+        />
+      </WithTooltip>
       <AudioUploader
         onSuccess={handleUploadSuccess}
       />

--- a/src/admin/ui/shared/assets/AudioSelector.tsx
+++ b/src/admin/ui/shared/assets/AudioSelector.tsx
@@ -6,7 +6,6 @@ import getFilenames from 'shared/util/getFilenames';
 import { Stack } from '@mui/material';
 import Selector, { makeOptions } from '../Selector';
 import AudioUploader from './AudioUploader';
-import WithTooltip from '../WithTooltip';
 
 const loadAudios = async (gameName: string) => {
   const s3 = new S3(`${gameName}/audio`);
@@ -42,14 +41,13 @@ const AudioSelector = ({
 
   return (
     <Stack direction="row" spacing={2}>
-      <WithTooltip text={tooltip}>
-        <Selector
-          label={label}
-          value={options.length ? (value || '') : ''}
-          onChange={onChange}
-          options={makeOptions(options)}
-        />
-      </WithTooltip>
+      <Selector
+        label={label}
+        value={options.length ? (value || '') : ''}
+        onChange={onChange}
+        options={makeOptions(options)}
+        tooltip={tooltip}
+      />
       <AudioUploader
         onSuccess={handleUploadSuccess}
       />

--- a/src/admin/ui/shared/assets/ImgSelector.tsx
+++ b/src/admin/ui/shared/assets/ImgSelector.tsx
@@ -5,13 +5,17 @@ import { addImage } from 'admin/store/reducers/gameStateReducer/imagesReducer';
 import { useDispatch, useSelector } from '../../hooks/redux';
 import ImageUploader from './ImageUploader';
 import Selector, { makeOptions } from '../Selector';
+import WithTooltip from '../WithTooltip';
 
 type Props = {
   label: string;
   value: Nullable<string>;
   onChange: (value: string) => void;
+  tooltip?: string;
 };
-const ImgSelector = ({ label, value, onChange }: Props) => {
+const ImgSelector = ({
+  label, value, onChange, tooltip,
+}: Props) => {
   const dispatch = useDispatch();
   const images = useSelector(state => state.gameState.images);
   const options = Object.keys(images);
@@ -32,12 +36,14 @@ const ImgSelector = ({ label, value, onChange }: Props) => {
 
   return (
     <Stack direction="row" spacing={2}>
-      <Selector
-        label={label}
-        value={value}
-        onChange={onChange}
-        options={makeOptions(options)}
-      />
+      <WithTooltip text={tooltip}>
+        <Selector
+          label={label}
+          value={value}
+          onChange={onChange}
+          options={makeOptions(options)}
+        />
+      </WithTooltip>
       <ImageUploader
         onSuccess={handleUploadSuccess}
       />

--- a/src/admin/ui/shared/assets/ImgSelector.tsx
+++ b/src/admin/ui/shared/assets/ImgSelector.tsx
@@ -5,7 +5,6 @@ import { addImage } from 'admin/store/reducers/gameStateReducer/imagesReducer';
 import { useDispatch, useSelector } from '../../hooks/redux';
 import ImageUploader from './ImageUploader';
 import Selector, { makeOptions } from '../Selector';
-import WithTooltip from '../WithTooltip';
 
 type Props = {
   label: string;
@@ -36,14 +35,13 @@ const ImgSelector = ({
 
   return (
     <Stack direction="row" spacing={2}>
-      <WithTooltip text={tooltip}>
-        <Selector
-          label={label}
-          value={value}
-          onChange={onChange}
-          options={makeOptions(options)}
-        />
-      </WithTooltip>
+      <Selector
+        label={label}
+        value={value}
+        onChange={onChange}
+        options={makeOptions(options)}
+        tooltip={tooltip}
+      />
       <ImageUploader
         onSuccess={handleUploadSuccess}
       />

--- a/src/admin/ui/shared/assets/VideoSelector.tsx
+++ b/src/admin/ui/shared/assets/VideoSelector.tsx
@@ -6,8 +6,6 @@ import getFilenames from 'shared/util/getFilenames';
 import { Stack } from '@mui/material';
 import Selector, { makeOptions } from '../Selector';
 import VideoUploader from './VideoUploader';
-import WithTooltip from '../WithTooltip';
-// import VideoUploader from './VideoUploader';
 
 const loadVideos = async (gameName: string) => {
   // TODO: this is almost the same as loadAudios
@@ -44,14 +42,13 @@ const VideoSelector = ({
 
   return (
     <Stack direction="row" spacing={2}>
-      <WithTooltip text={tooltip}>
-        <Selector
-          label={label}
-          value={options.length ? (value || '') : ''}
-          onChange={onChange}
-          options={makeOptions(options)}
-        />
-      </WithTooltip>
+      <Selector
+        label={label}
+        value={options.length ? (value || '') : ''}
+        onChange={onChange}
+        options={makeOptions(options)}
+        tooltip={tooltip}
+      />
       <VideoUploader
         onSuccess={handleUploadSuccess}
       />

--- a/src/admin/ui/shared/assets/VideoSelector.tsx
+++ b/src/admin/ui/shared/assets/VideoSelector.tsx
@@ -6,6 +6,7 @@ import getFilenames from 'shared/util/getFilenames';
 import { Stack } from '@mui/material';
 import Selector, { makeOptions } from '../Selector';
 import VideoUploader from './VideoUploader';
+import WithTooltip from '../WithTooltip';
 // import VideoUploader from './VideoUploader';
 
 const loadVideos = async (gameName: string) => {
@@ -20,8 +21,11 @@ type Props = {
   label: string;
   value: Nullable<string>;
   onChange: (value: string) => void;
+  tooltip?: string;
 };
-const VideoSelector = ({ label, value, onChange }: Props) => {
+const VideoSelector = ({
+  label, value, onChange, tooltip,
+}: Props) => {
   const { gameName } = useParams<{ gameName: string }>();
   const [options, setOptions] = useState<Nullable<string[]>>(null);
 
@@ -40,13 +44,14 @@ const VideoSelector = ({ label, value, onChange }: Props) => {
 
   return (
     <Stack direction="row" spacing={2}>
-      <Selector
-        label={label}
-        value={options.length ? (value || '') : ''}
-        onChange={onChange}
-        options={makeOptions(options)}
-      />
-
+      <WithTooltip text={tooltip}>
+        <Selector
+          label={label}
+          value={options.length ? (value || '') : ''}
+          onChange={onChange}
+          options={makeOptions(options)}
+        />
+      </WithTooltip>
       <VideoUploader
         onSuccess={handleUploadSuccess}
       />

--- a/src/admin/ui/verbs/AddVerb.tsx
+++ b/src/admin/ui/verbs/AddVerb.tsx
@@ -10,6 +10,7 @@ import { useDispatch } from '../hooks/redux';
 const useStyles = makeStyles({
   addVerb: {
     margin: '20px 0',
+    alignItems: 'center',
   },
 });
 


### PR DESCRIPTION
This adds a reusable Tooltip component that can be attached to different types of form fields. I filled in a bunch of the easy ones, but there are probably more places we will want it. Also fixed some related styles