### PR TITLE
add a sticky header component

### DIFF
--- a/src/admin/AdminContainer.tsx
+++ b/src/admin/AdminContainer.tsx
@@ -4,6 +4,7 @@ import styles from './Admin.module.css';
 import { clearSelected } from './store/reducers/editorStateReducer/selectedEntityReducer';
 import { useDispatch } from './ui/hooks/redux';
 import GamePreview from './ui/preview/GamePreview';
+import AdminHeader from './ui/shared/AdminHeader';
 
 type Props = {
   children: React.ReactNode;
@@ -23,6 +24,7 @@ const AdminContainer = ({ children }: Props) => {
   return (
     <div className={styles.adminContainer}>
       <GamePreview />
+      <AdminHeader />
       {children}
     </div>
   );

--- a/src/admin/ui/config/gameLayout/index.tsx
+++ b/src/admin/ui/config/gameLayout/index.tsx
@@ -1,11 +1,8 @@
 import React from 'react';
 import Grid from '@mui/material/Grid';
-import Typography from '@mui/material/Typography';
 import { setImageConfig } from 'admin/store/reducers/gameStateReducer/configReducer/imgReducer';
 import { setColors } from 'admin/store/reducers/gameStateReducer/configReducer/colorsReducer';
-import { Link, useParams } from 'react-router-dom';
-import { Box, Button } from '@mui/material';
-import { ArrowBack } from '@mui/icons-material';
+import { Box } from '@mui/material';
 import EntityDetails from 'admin/ui/rooms/EntityDetails';
 import { makeStyles } from '@mui/styles';
 import LongTextField from 'admin/ui/shared/LongTextField';
@@ -30,7 +27,6 @@ const useStyles = makeStyles({
 });
 
 const GameLayout = () => {
-  const { gameName } = useParams<{ gameName: string }>();
   const dispatch = useDispatch();
   const styles = useStyles();
   const {
@@ -42,20 +38,6 @@ const GameLayout = () => {
     <>
       <Box className={styles.leftColumn}>
         <Grid container>
-          <Grid item xs={12}>
-            <Link to={`/admin/${gameName}/config`}>
-              <Button
-                startIcon={<ArrowBack>back</ArrowBack>}
-              >
-                To Config Edit
-              </Button>
-            </Link>
-          </Grid>
-          <Grid item xs={12}>
-            <Typography variant="h4">
-              Edit Game UI:
-            </Typography>
-          </Grid>
           <Grid item xs={12}>
             <GameLayoutWidget />
           </Grid>

--- a/src/admin/ui/config/index.tsx
+++ b/src/admin/ui/config/index.tsx
@@ -6,7 +6,6 @@ import { useParams } from 'react-router-dom';
 import useStyles from '../shared/useStyles';
 import Player from './Player';
 import Flags from './Flags';
-import SaveButton from '../shared/SaveButton';
 import EntityDetails from '../rooms/EntityDetails';
 import GameName from './GameName';
 import Password from './Password';
@@ -23,9 +22,6 @@ const ConfigPage = () => {
           <Player />
           <Flags />
         </Grid>
-        <Stack direction="row" spacing={2}>
-          <SaveButton />
-        </Stack>
       </Box>
       <Box className={styles.rightColumn}>
         <EntityDetails />

--- a/src/admin/ui/config/index.tsx
+++ b/src/admin/ui/config/index.tsx
@@ -1,12 +1,8 @@
 import React from 'react';
 import Grid from '@mui/material/Grid';
 import Box from '@mui/material/Box';
-import Typography from '@mui/material/Typography';
 import Stack from '@mui/material/Stack';
-import { Link, useParams } from 'react-router-dom';
-import { Button } from '@mui/material';
-import ArrowBack from '@mui/icons-material/ArrowBack';
-import { ArrowForward } from '@mui/icons-material';
+import { useParams } from 'react-router-dom';
 import useStyles from '../shared/useStyles';
 import Player from './Player';
 import Flags from './Flags';
@@ -22,29 +18,6 @@ const ConfigPage = () => {
     <>
       <Box className={styles.leftColumn}>
         <Grid container>
-          <Grid item xs={12}>
-            <Link to={`/admin/${gameName}`}>
-              <Button
-                startIcon={<ArrowBack>back</ArrowBack>}
-              >
-                To Home
-              </Button>
-            </Link>
-          </Grid>
-          <Grid item xs={12}>
-            <Link to={`/admin/${gameName}/config/ui`}>
-              <Button
-                startIcon={<ArrowForward>forward</ArrowForward>}
-              >
-                Edit Game UI
-              </Button>
-            </Link>
-          </Grid>
-          <Grid item xs={12}>
-            <Typography variant="h4">
-              Edit Game Config:
-            </Typography>
-          </Grid>
           <GameName />
           <Password gameName={gameName} />
           <Player />

--- a/src/admin/ui/home/Home.tsx
+++ b/src/admin/ui/home/Home.tsx
@@ -1,54 +1,30 @@
 import { Link } from 'react-router-dom';
 import React from 'react';
 import { Box, Button } from '@mui/material';
-import ArrowBack from '@mui/icons-material/ArrowBack';
-import { ArrowForward } from '@mui/icons-material';
 
 type Props = {
   gameName: string;
 };
 const Home = ({ gameName }: Props) => {
   return (
-    <div>
-      <div>
-        GameName:
-        {' '}
-        {gameName}
-      </div>
-      <Box style={{ width: '100% ' }}>
-        {/*
-          Making this an actual hyperlink for now, since Link can't seem to
-          find the parent Route component properly
-        */}
-        <a href="/admin">
-          <Button
-            startIcon={<ArrowBack>back</ArrowBack>}
-          >
-            To Games List
-          </Button>
-        </a>
-      </Box>
-      <Box style={{ width: '100% ' }}>
-        <Link to={`/admin/${gameName}/rooms`}>
-          <Button
-            endIcon={<ArrowForward>back</ArrowForward>}
-          >
-            To Rooms List
+    <Box style={{ width: '100% ' }}>
+      <Link to={`/admin/${gameName}/rooms`}>
+        <Button>
+          Edit Rooms
 
-          </Button>
-        </Link>
-      </Box>
-      <Box style={{ width: '100% ' }}>
-        <Link to={`/admin/${gameName}/config`}>
-          <Button
-            endIcon={<ArrowForward>back</ArrowForward>}
-          >
-            To Config
-
-          </Button>
-        </Link>
-      </Box>
-    </div>
+        </Button>
+      </Link>
+      <Link to={`/admin/${gameName}/config`}>
+        <Button>
+          Edit Config
+        </Button>
+      </Link>
+      <Link to={`/admin/${gameName}/config/ui`}>
+        <Button>
+          Edit UI
+        </Button>
+      </Link>
+    </Box>
   );
 };
 

--- a/src/admin/ui/rooms/ListRooms.tsx
+++ b/src/admin/ui/rooms/ListRooms.tsx
@@ -6,8 +6,7 @@ import Tooltip from '@mui/material/Tooltip';
 import Videocam from '@mui/icons-material/Videocam';
 import { Room } from 'game/store/types';
 import { createRoom, deleteRoom } from 'admin/store/reducers/gameStateReducer/worldStateReducer/roomsReducer';
-import { Button, IconButton, Typography } from '@mui/material';
-import ArrowBack from '@mui/icons-material/ArrowBack';
+import { IconButton, Typography } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { useSelector, useDispatch } from '../hooks/redux';
 import useStyles from '../shared/useStyles';
@@ -85,7 +84,6 @@ const RoomCard = ({ room, id }: RoomCardProps) => {
 };
 
 const ListRooms = () => {
-  const { gameName } = useParams<{ gameName: string }>();
   const classes = useStyles();
   const dispatch = useDispatch();
   const rooms = useSelector(state => state.gameState.worldState.rooms);
@@ -96,15 +94,6 @@ const ListRooms = () => {
 
   return (
     <Box className={classes.roomsPreview}>
-      <Box style={{ width: '100%' }}>
-        <Link to={`/admin/${gameName}`}>
-          <Button
-            startIcon={<ArrowBack>back</ArrowBack>}
-          >
-            To Home
-          </Button>
-        </Link>
-      </Box>
       {Object.entries(rooms).map(([id, room]) => (
         <RoomCard key={id} id={id} room={room} />
       ))}

--- a/src/admin/ui/rooms/RoomDetails.tsx
+++ b/src/admin/ui/rooms/RoomDetails.tsx
@@ -9,13 +9,11 @@ import { useDispatch } from '../hooks/redux';
 import LongTextField from '../shared/LongTextField';
 import useStyles from '../shared/useStyles';
 import TestGameButton from '../shared/TestGameButton';
-import SaveButton from '../shared/SaveButton';
 import PreviewWidget from '../preview/PreviewWidget';
 import ImgSelector from '../shared/assets/ImgSelector';
 import AudioSelector from '../shared/assets/AudioSelector';
 import VideoSelector from '../shared/assets/VideoSelector';
 import Toggle from '../shared/Toggle';
-import PublishButton from '../shared/PublishButton';
 
 type Props = { room: Room; roomId: number };
 const RoomDetails = ({ room, roomId }: Props) => {
@@ -98,8 +96,6 @@ const RoomDetails = ({ room, roomId }: Props) => {
         </Grid>
         <Stack direction="row" spacing={2}>
           <TestGameButton roomId={roomId} />
-          <SaveButton />
-          <PublishButton />
         </Stack>
       </Grid>
     </Box>

--- a/src/admin/ui/rooms/RoomDetails.tsx
+++ b/src/admin/ui/rooms/RoomDetails.tsx
@@ -2,10 +2,7 @@ import React from 'react';
 import Grid from '@mui/material/Grid';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
-import Button from '@mui/material/Button';
 import Stack from '@mui/material/Stack';
-import { useParams, Link } from 'react-router-dom';
-import ArrowBack from '@mui/icons-material/ArrowBack';
 import { setRoom } from 'admin/store/reducers/gameStateReducer/worldStateReducer/roomsReducer';
 import { Room } from 'game/store/types';
 import { useDispatch } from '../hooks/redux';
@@ -18,12 +15,10 @@ import ImgSelector from '../shared/assets/ImgSelector';
 import AudioSelector from '../shared/assets/AudioSelector';
 import VideoSelector from '../shared/assets/VideoSelector';
 import Toggle from '../shared/Toggle';
-import TooltipToggle from './TooltipToggle';
 import PublishButton from '../shared/PublishButton';
 
 type Props = { room: Room; roomId: number };
 const RoomDetails = ({ room, roomId }: Props) => {
-  const { gameName } = useParams<{ gameName: string }>();
   const dispatch = useDispatch();
   const styles = useStyles();
 
@@ -44,23 +39,6 @@ const RoomDetails = ({ room, roomId }: Props) => {
   return (
     <Box className={styles.leftColumn}>
       <Grid container>
-        <TooltipToggle />
-        <Grid item xs={12}>
-          <Link to={`/admin/${gameName}/rooms`}>
-            <Button
-              startIcon={<ArrowBack>back</ArrowBack>}
-            >
-              To Rooms List
-            </Button>
-          </Link>
-        </Grid>
-        <Grid item xs={12}>
-          <Typography variant="h4">
-            Edit Room:
-            {' '}
-            {roomId}
-          </Typography>
-        </Grid>
         <Grid item xs={12}>
           <LongTextField
             label="initial description"

--- a/src/admin/ui/shared/AdminHeader.tsx
+++ b/src/admin/ui/shared/AdminHeader.tsx
@@ -5,6 +5,8 @@ import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { ArrowBack } from '@mui/icons-material';
 import TooltipToggle from '../rooms/TooltipToggle';
+import SaveButton from './SaveButton';
+import PublishButton from './PublishButton';
 
 const getRoomHeading = (path: string) => {
   const pathParts = path.split('/');
@@ -79,7 +81,7 @@ const AdminHeader = () => {
     heading, backText, backLink, useRealLink,
   } = usePageHeaderInfo();
   return (
-    <AppBar position="static" color="transparent">
+    <AppBar position="sticky" color="inherit">
       <Toolbar>
         <BackLink backLink={backLink} useRealLink={!!useRealLink}>
           <Button
@@ -88,9 +90,11 @@ const AdminHeader = () => {
             {backText}
           </Button>
         </BackLink>
-        <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
+        <Typography variant="h6" component="div" sx={{ flexGrow: 1 }} textAlign="center">
           {heading}
         </Typography>
+        <SaveButton />
+        <PublishButton />
         <TooltipToggle />
       </Toolbar>
     </AppBar>

--- a/src/admin/ui/shared/AdminHeader.tsx
+++ b/src/admin/ui/shared/AdminHeader.tsx
@@ -1,0 +1,81 @@
+import {
+  AppBar, Button, IconButton, Toolbar, Typography,
+} from '@mui/material';
+import React from 'react';
+import MenuIcon from '@mui/icons-material/Menu';
+import { useLocation } from 'react-router-dom';
+
+const getRoomHeading = (path: string) => {
+  const pathParts = path.split('/');
+  const roomNumber = pathParts[pathParts.length - 1];
+  return `Room ${roomNumber}`;
+};
+
+const hackilyGetPageHeaderInfo = (gameName: string, path: string) => {
+  switch (path) {
+    case '':
+      return {
+        heading: 'Home',
+        backText: 'To Games List',
+        backLink: '/admin',
+      };
+    case 'rooms':
+      return {
+        heading: 'Rooms',
+        backText: 'To Home',
+        backLink: `/admin/${gameName}`,
+      };
+    case 'config':
+      return {
+        heading: 'Edit Config',
+        backText: 'To Home',
+        backLink: `/admin/${gameName}`,
+      };
+    case 'config/ui':
+      return {
+        heading: 'Edit UI',
+        backText: 'To Home',
+        backLink: `/admin/${gameName}`,
+      };
+    default:
+      return {
+        heading: getRoomHeading(path),
+        backText: 'To Rooms',
+        backLink: `/admin/${gameName}/rooms`,
+      };
+  }
+};
+
+const usePageHeaderInfo = () => {
+  const location = useLocation();
+  const pathParts = location.pathname.split('/');
+  const gameName = pathParts[2];
+  const pathSuffix = pathParts.slice(3).join('/');
+
+  return hackilyGetPageHeaderInfo(gameName, pathSuffix);
+};
+
+const AdminHeader = () => {
+  const { heading, backText, backLink } = usePageHeaderInfo();
+  return (
+    <AppBar position="static" color="transparent">
+      <Toolbar>
+        <IconButton
+          size="large"
+          edge="start"
+          color="inherit"
+          aria-label="menu"
+          sx={{ mr: 2 }}
+        >
+          <MenuIcon />
+        </IconButton>
+        <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
+          {heading}
+        </Typography>
+        <Button color="inherit">Login</Button>
+      </Toolbar>
+    </AppBar>
+  );
+};
+
+export default AdminHeader;

--- a/src/admin/ui/shared/AdminHeader.tsx
+++ b/src/admin/ui/shared/AdminHeader.tsx
@@ -1,14 +1,15 @@
 import {
-  AppBar, Button, IconButton, Toolbar, Typography,
+  AppBar, Button, Toolbar, Typography,
 } from '@mui/material';
 import React from 'react';
-import MenuIcon from '@mui/icons-material/Menu';
-import { useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
+import { ArrowBack } from '@mui/icons-material';
+import TooltipToggle from '../rooms/TooltipToggle';
 
 const getRoomHeading = (path: string) => {
   const pathParts = path.split('/');
   const roomNumber = pathParts[pathParts.length - 1];
-  return `Room ${roomNumber}`;
+  return `Edit Room ${roomNumber}`;
 };
 
 const hackilyGetPageHeaderInfo = (gameName: string, path: string) => {
@@ -18,6 +19,7 @@ const hackilyGetPageHeaderInfo = (gameName: string, path: string) => {
         heading: 'Home',
         backText: 'To Games List',
         backLink: '/admin',
+        useRealLink: true,
       };
     case 'rooms':
       return {
@@ -55,24 +57,41 @@ const usePageHeaderInfo = () => {
   return hackilyGetPageHeaderInfo(gameName, pathSuffix);
 };
 
+type Props = {
+  children: React.ReactNode;
+  backLink: string;
+  useRealLink: boolean;
+};
+const BackLink = (props: Props) => {
+  const { children, backLink, useRealLink } = props;
+
+  if (useRealLink) {
+    return (
+      <a href={backLink}>{children}</a>
+    );
+  }
+
+  return <Link to={backLink}>{children}</Link>;
+};
+
 const AdminHeader = () => {
-  const { heading, backText, backLink } = usePageHeaderInfo();
+  const {
+    heading, backText, backLink, useRealLink,
+  } = usePageHeaderInfo();
   return (
     <AppBar position="static" color="transparent">
       <Toolbar>
-        <IconButton
-          size="large"
-          edge="start"
-          color="inherit"
-          aria-label="menu"
-          sx={{ mr: 2 }}
-        >
-          <MenuIcon />
-        </IconButton>
+        <BackLink backLink={backLink} useRealLink={!!useRealLink}>
+          <Button
+            startIcon={<ArrowBack>back</ArrowBack>}
+          >
+            {backText}
+          </Button>
+        </BackLink>
         <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
           {heading}
         </Typography>
-        <Button color="inherit">Login</Button>
+        <TooltipToggle />
       </Toolbar>
     </AppBar>
   );

--- a/src/admin/ui/shared/AuthGate.tsx
+++ b/src/admin/ui/shared/AuthGate.tsx
@@ -2,7 +2,6 @@
 import * as React from 'react';
 import Avatar from '@mui/material/Avatar';
 import LoadingButton from '@mui/lab/LoadingButton';
-import CssBaseline from '@mui/material/CssBaseline';
 import TextField from '@mui/material/TextField';
 import Box from '@mui/material/Box';
 import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
@@ -42,7 +41,6 @@ const AuthGate = (props: Props) => {
 
   return (
     <Container component="main" maxWidth="xs">
-      <CssBaseline />
       <Box
         sx={{
           marginTop: 8,

--- a/src/admin/ui/shared/DispatchButton.tsx
+++ b/src/admin/ui/shared/DispatchButton.tsx
@@ -21,6 +21,7 @@ const DispatchButton = (props: Props) => {
       color={color}
       disabled={disabled}
       onClick={onClick}
+      sx={{ mt: 1, mb: 1 }}
     >
       {callToAction}
     </Button>

--- a/src/admin/ui/shared/PublishButton.tsx
+++ b/src/admin/ui/shared/PublishButton.tsx
@@ -5,13 +5,13 @@ import useUpload, { UploadState } from '../hooks/useUpload';
 const getCallToAction = (uploadState: UploadState) => {
   switch (uploadState) {
     case UploadState.IN_PROGRESS:
-      return 'Publishing...';
+      return 'Publishing Game...';
     case UploadState.COMPLETE:
-      return 'Published!';
+      return 'Published Game!';
     case UploadState.ERROR:
       return 'Something went wrong (check console)';
     default:
-      return 'Publish';
+      return 'Publish Game';
   }
 };
 
@@ -25,6 +25,7 @@ const PublishButton = () => {
       color="primary"
       disabled={uploadState !== UploadState.NONE}
       onClick={upload}
+      sx={{ ml: 1, mr: 1 }}
     >
       {callToAction}
     </Button>

--- a/src/admin/ui/shared/SaveButton.tsx
+++ b/src/admin/ui/shared/SaveButton.tsx
@@ -5,13 +5,13 @@ import useUpload, { UploadState } from '../hooks/useUpload';
 const getCallToAction = (uploadState: UploadState) => {
   switch (uploadState) {
     case UploadState.IN_PROGRESS:
-      return 'Saving...';
+      return 'Saving Game...';
     case UploadState.COMPLETE:
-      return 'Saved!';
+      return 'Saved Game!';
     case UploadState.ERROR:
       return 'Something went wrong (check console)';
     default:
-      return 'Save';
+      return 'Save Game';
   }
 };
 
@@ -25,6 +25,7 @@ const SaveButton = () => {
       color="primary"
       disabled={uploadState !== UploadState.NONE}
       onClick={upload}
+      sx={{ ml: 1, mr: 1 }}
     >
       {callToAction}
     </Button>

--- a/src/admin/ui/shared/TestGameButton.tsx
+++ b/src/admin/ui/shared/TestGameButton.tsx
@@ -8,7 +8,7 @@ type Props = {
 const PreviewButton = ({ roomId }: Props) => (
   <DispatchButton
     action={startPreview(roomId)}
-    callToAction="Test Game"
+    callToAction="Test Play This Room"
   />
 );
 


### PR DESCRIPTION
This moves some common functionality to a fixed header to make the pages a little less overwhelming.

<img width="1792" alt="Screen Shot 2022-07-10 at 10 27 12 PM" src="https://user-images.githubusercontent.com/4368490/178177671-2c352dc5-02ae-4632-b1c3-04ae62734020.png">
