### PR TITLE
Make verbs more flexible

### DIFF
--- a/src/admin/ui/verbs/Verb.tsx
+++ b/src/admin/ui/verbs/Verb.tsx
@@ -84,7 +84,7 @@ const Verb = ({
         <Selector
           label="prereq using"
           value={verb.prereqUsing}
-          onChange={onChange('prereqUsing')}
+          onChange={val => onChange('prereqUsing')(parseInt(val, 10))}
           options={makeOptions(allEntityIds)}
           style={{ width: '150px' }}
         />

--- a/src/game/store/reducers/selectItemReducer.ts
+++ b/src/game/store/reducers/selectItemReducer.ts
@@ -1,6 +1,6 @@
 import { compose } from 'redux';
 import { ItemReducer, ParentReducer } from 'shared/util/types';
-import { Item, VerbIndex } from '../types';
+import { Item, VerbConfig, VerbIndex } from '../types';
 import {
   setValue, updateValue, withText, keepState, filterValues,
 } from './utils';
@@ -24,32 +24,27 @@ export const useReducer: ItemReducer = ({ id }) => compose(
   setValue('playerState.using')(id),
 );
 
-const defaultReducer = () => withText('You seem to be wasting your time.');
 const lookReducer = (description: string) => () => withText(description);
 
-type GetReducer = (verb: VerbIndex, item: Item) => ItemReducer;
-const getReducer: GetReducer = (verb, item) => {
-  switch (verb) {
+type GetReducer = (verbIndex: VerbIndex, item: Item, verbs: VerbConfig[]) => ItemReducer;
+const getReducer: GetReducer = (verbIndex, item, verbs) => {
+  switch (verbIndex) {
     case 3:
       return useReducer;
     case 5:
       return takeReducer;
-    case 4:
-      return genericVerbReducer(4, () => 'Smoking that would be ill-advised!');
-    case 6:
-      return genericVerbReducer(6, () => 'test this eating thing');
     case 1:
       return lookReducer(item.description);
     default:
-      return defaultReducer;
+      return genericVerbReducer(verbIndex, () => verbs[verbIndex].defaultText);
   }
 };
 
-const selectItemReducer: ParentReducer<number> = (id, playerState, worldState, _flags) => {
+const selectItemReducer: ParentReducer<number> = (id, playerState, worldState, _flags, verbs) => {
   const entity = worldState.entities[id];
   // TODO: devise a better way to ensure the right type of entity gets here
   if (entity.type === 'items') {
-    const reducer = getReducer(playerState.verb, entity);
+    const reducer = getReducer(playerState.verb, entity, verbs);
     return reducer(entity, playerState, _flags);
   }
 

--- a/src/game/store/reducers/selectItemReducer.ts
+++ b/src/game/store/reducers/selectItemReducer.ts
@@ -36,7 +36,7 @@ const getReducer: GetReducer = (verbIndex, item, verbs) => {
     case 1:
       return lookReducer(item.description);
     default:
-      return genericVerbReducer(verbIndex, () => verbs[verbIndex].defaultText);
+      return genericVerbReducer(verbIndex, () => withText(verbs[verbIndex].defaultText));
   }
 };
 

--- a/src/game/store/reducers/selectObjectReducer.ts
+++ b/src/game/store/reducers/selectObjectReducer.ts
@@ -2,22 +2,24 @@ import { ParentReducer } from 'shared/util/types';
 import moveReducer from './verbReducers/moveReducer';
 import openReducer from './verbReducers/openReducer';
 import takeReducer from './verbReducers/takeReducer';
-import _useReducer from './verbReducers/useReducer';
-import { keepState } from './utils';
+import _useReducer, { forfeitItemReducer } from './verbReducers/useReducer';
+import { keepState, withText } from './utils';
 import { VerbIndex, VerbConfig } from '../types';
 import genericVerbReducer from './verbReducers/genericVerbReducer';
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const getReducer = (verb: VerbIndex, verbs: VerbConfig[]) => ([
-  moveReducer,
-  genericVerbReducer(1, object => object.description),
-  openReducer,
-  _useReducer,
-  genericVerbReducer(4, () => verbs[4].defaultText),
-  takeReducer,
-  genericVerbReducer(6, () => verbs[6].defaultText),
-  genericVerbReducer(7, () => verbs[7].defaultText),
-  genericVerbReducer(8, () => verbs[8].defaultText),
+  // TODO: None of these behaviors should be hardcoded. Special behaviors like
+  // MOVE and TAKE should be user-selected in the verb config. In a way,
+  // defaultText is just another special behavior.
+  genericVerbReducer(0, moveReducer),
+  genericVerbReducer(1, object => withText(object.description)),
+  genericVerbReducer(2, openReducer),
+  genericVerbReducer(3, _useReducer, forfeitItemReducer),
+  genericVerbReducer(4, () => withText(verbs[4].defaultText)),
+  genericVerbReducer(5, takeReducer),
+  genericVerbReducer(6, () => withText(verbs[6].defaultText)),
+  genericVerbReducer(7, () => withText(verbs[7].defaultText)),
+  genericVerbReducer(8, () => withText(verbs[8].defaultText)),
 ][verb]);
 
 type GenericReducer = (t: 'doors' | 'entities') => ParentReducer<number>;

--- a/src/game/store/reducers/verbReducers/genericVerbReducer.ts
+++ b/src/game/store/reducers/verbReducers/genericVerbReducer.ts
@@ -46,22 +46,22 @@ const getVerbLogic: GetVerbLogic = (object, verb, using, flags) => {
   return null;
 };
 
-type GetDefaultText = (object: Entity) => Nullable<string>;
 type GenericVerbReducer = (
   verb: VerbIndex,
-  getDefaultText: GetDefaultText,
-  extraReducer?: EntityReducer
+  failureReducer: EntityReducer,
+  successReducer?: EntityReducer
 ) => EntityReducer;
-const genericVerbReducer: GenericVerbReducer = (verb, getDefaultText, extraReducer = keepState) => {
+// eslint-disable-next-line max-len
+const genericVerbReducer: GenericVerbReducer = (verb, failureReducer, successReducer = keepState) => {
   return (object, playerState, flags) => {
     const logic = getVerbLogic(object, verb, playerState.using, flags);
 
     if (!logic) {
       if (object.type === 'scenery' && object.trigger === verb) {
-        // Don't display default text if this triggers an animation
+        // For now, ignore side effects if this triggers an animation
         return keepState();
       }
-      return withText(getDefaultText(object));
+      return failureReducer(object, playerState, flags);
     }
 
     if (logic.moveTo && logic.moveDir) {
@@ -76,7 +76,7 @@ const genericVerbReducer: GenericVerbReducer = (verb, getDefaultText, extraReduc
       when(!!logic.removeFlags)(removeFlags(logic.removeFlags || [])),
       withText(logic.text),
       effectsReducer(logic),
-      extraReducer(object, playerState, flags),
+      successReducer(object, playerState, flags),
     );
   };
 };

--- a/src/game/store/reducers/verbReducers/useReducer.ts
+++ b/src/game/store/reducers/verbReducers/useReducer.ts
@@ -15,7 +15,11 @@ const useDoorReducer: DoorReducer = (object, playerState) => {
     );
   }
 
-  return withText('Damn. Didn\'t work. The damned door is still locked.');
+  if (playerState.using) {
+    return withText('Damn. Didn\'t work. The damned door is still locked.');
+  }
+
+  return withText('What you expected hasn\'t happened, and that really sucks.');
 };
 
 const forfeitItemReducer: EntityReducer = (_o, playerState) => filterValues('playerState.items')(playerState.using);

--- a/src/game/store/reducers/verbReducers/useReducer.ts
+++ b/src/game/store/reducers/verbReducers/useReducer.ts
@@ -4,7 +4,6 @@ import { DoorReducer, EntityReducer } from 'shared/util/types';
 import {
   withText, setValue, clearValue, filterValues, combineReducers,
 } from '../utils';
-import genericVerbReducer from './genericVerbReducer';
 import { useReducer as setUsingReducer } from '../selectItemReducer';
 
 const useDoorReducer: DoorReducer = (object, playerState) => {
@@ -16,13 +15,16 @@ const useDoorReducer: DoorReducer = (object, playerState) => {
   }
 
   if (playerState.using) {
-    return withText('Damn. Didn\'t work. The damned door is still locked.');
+    return withText('Damn. Didn\'t work. The damn door is still locked.');
   }
 
   return withText('What you expected hasn\'t happened, and that really sucks.');
 };
 
-const forfeitItemReducer: EntityReducer = (_o, playerState) => filterValues('playerState.items')(playerState.using);
+export const forfeitItemReducer: EntityReducer = combineReducers(
+  (_o, playerState) => filterValues('playerState.items')(playerState.using),
+  () => clearValue('playerState.using'),
+);
 
 const useReducerForType: EntityReducer = (object, playerState, flags) => {
   if (!playerState.using && object.type === 'items') {
@@ -33,7 +35,7 @@ const useReducerForType: EntityReducer = (object, playerState, flags) => {
     return useDoorReducer(object, playerState, flags);
   }
 
-  return genericVerbReducer(3, () => 'That ain\'t workin!\'!', forfeitItemReducer)(object, playerState, flags);
+  return withText('That ain\'t workin!\'!');
 };
 
 const useReducer: EntityReducer = combineReducers(


### PR DESCRIPTION
This tries to generalize the concept of what happens when the conditions for a certain verb logic fail or succeed. There are a couple of goals with it:

1. Make it so that any verb you configure prioritizes generic admin-defined behavior (before this, if you tried to configure MOVE, for example, it would just be ignored in favor of the hard-coded MOVE behavior. Now you can override it)
2. Make every verb totally configurable (this will be a followup task). Right now, you have no choice but to have a verb that does the MOVE behavior, and one that does TAKE, etc, by default. As a convenience, the logic behind those actions should still be codified, but we shouldn't _force_ you to use it. Instead, you opt into those behaviors in the verb config admin page. I'm probably not articulating that well, but the followup PR to this should clear it up