### PR TITLE
Flexible Verbs, pt 2

### DIFF
--- a/src/admin/store/reducers/gameStateReducer/worldStateReducer/roomsReducer.ts
+++ b/src/admin/store/reducers/gameStateReducer/worldStateReducer/roomsReducer.ts
@@ -72,7 +72,7 @@ export const roomsSlice = createSlice({
       // TODO: What do we do about doors that point to this room?
       // - Probably don't want to delete the door. Might still want it.
       // - We probably do want to enforce that doors point somewhere (right?)
-      // - We probably don't wna tto choos a random room. Too annoying
+      // - We probably don't wnat to choose a random room. Too annoying
       // - So it sounds like we want a panel that displays all current errors
       // - Also, this is another case for introducing logic-level validation
     },

--- a/src/admin/ui/config/gameLayout/VerbDetails.tsx
+++ b/src/admin/ui/config/gameLayout/VerbDetails.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { useSelector, useDispatch } from 'admin/ui/hooks/redux';
-import { Stack } from '@mui/material';
+import { Stack, Typography } from '@mui/material';
 import LongTextField from 'admin/ui/shared/LongTextField';
-import { Nullable } from 'game/store/types';
+import { Nullable, VerbBehavior, VerbConfig } from 'game/store/types';
 import { setVerb } from 'admin/store/reducers/gameStateReducer/configReducer/verbsReducer';
+import Selector, { makeOptions } from 'admin/ui/shared/Selector';
 
 const VerbDetails = () => {
   const dispatch = useDispatch();
@@ -22,57 +23,62 @@ const VerbDetails = () => {
     return null;
   }
 
-  const handleChange = (verbName: Nullable<string>, index: number) => {
-    if (!verbName) {
+  const handleChange = (key: keyof VerbConfig) => (value: Nullable<string | number>) => {
+    const newVerb = {
+      ...verb,
+      [key]: value,
+    };
+
+    if (!newVerb.name) {
       console.log('You gotta have a verbName');
       return;
     }
 
-    if (verbName.length < 1) {
+    if (newVerb.name.length < 1) {
       console.log('Each verbName must contain at least 1 character.');
       return;
     }
-    if (verbName.length > 5) {
+    if (newVerb.name.length > 5) {
       console.log('Each verbName must contain at most 5 characters.');
       return;
     }
 
-    dispatch(setVerb({
-      verb: {
-        name: verbName,
-        defaultText: verb.defaultText,
-      },
-      index,
-    }));
-  };
-
-  const handleDefaultTextChange = (defaultText: Nullable<string>, index: number) => {
-    if (!defaultText) {
-      console.log('You gotta have text');
+    if (!newVerb.defaultText && newVerb.defaultBehavior === VerbBehavior.NONE) {
+      console.log('OK, look. You gotta have either defaultText or defaultBehavior.');
       return;
     }
 
     dispatch(setVerb({
-      verb: {
-        name: verb.name,
-        defaultText,
-      },
-      index,
+      verb: newVerb,
+      index: newVerb.index,
     }));
   };
 
   return (
-    <Stack direction="row" spacing={2} key={verb.index}>
+    <Stack direction="column" key={verb.index}>
+      <Typography variant="h6">
+        Edit Verb
+        {' '}
+        {verb.index}
+      </Typography>
       <LongTextField
-        label={`verb ${verb.index} name`}
+        label="name"
         value={verb.name}
         fullWidth={false}
-        onChange={value => handleChange(value, verb.index)}
+        onChange={handleChange('name')}
       />
       <LongTextField
-        label={`verb ${verb.index} default text`}
+        label="default text"
         value={verb.defaultText}
-        onChange={value => handleDefaultTextChange(value, verb.index)}
+        onChange={handleChange('defaultText')}
+      />
+      <Selector
+        required
+        label="default behavior"
+        value={verb.defaultBehavior}
+        onChange={handleChange('defaultBehavior')}
+        options={makeOptions(Object.values(VerbBehavior))}
+        tooltip="This defines default behavior for when you don't supply any behavior for a particular object + verb."
       />
     </Stack>
   );

--- a/src/admin/ui/hooks/useCommand.ts
+++ b/src/admin/ui/hooks/useCommand.ts
@@ -1,0 +1,37 @@
+import { useCallback, useEffect, useState } from 'react';
+
+const useCommand = (char: string, callback: () => void) => {
+  const [cmdPressed, setCmdPressed] = useState(false);
+
+  const keydown = useCallback((e: KeyboardEvent) => {
+    if (e.key === 'Meta') {
+      e.preventDefault();
+      setCmdPressed(true);
+    }
+
+    if (e.key === char) {
+      if (cmdPressed) {
+        e.preventDefault();
+        callback();
+      }
+    }
+  }, [cmdPressed]);
+
+  const keyup = useCallback((e: KeyboardEvent) => {
+    if (e.key === 'Meta') {
+      e.preventDefault();
+      setCmdPressed(false);
+    }
+  }, [cmdPressed]);
+
+  useEffect(() => {
+    window.addEventListener('keydown', keydown);
+    window.addEventListener('keyup', keyup);
+    return () => {
+      window.removeEventListener('keydown', keydown);
+      window.removeEventListener('keyup', keyup);
+    };
+  }, [keydown, keyup]);
+};
+
+export default useCommand;

--- a/src/admin/ui/hooks/useReordering.ts
+++ b/src/admin/ui/hooks/useReordering.ts
@@ -10,7 +10,7 @@ const useReordering = (entity: Entity, roomId?: number, type: ReorderType = 'ent
 
   useEffect(() => {
     const keydown = (e: KeyboardEvent) => {
-      if (!roomId || !isSelected(entity, selectedEnt)) {
+      if (roomId == null || !isSelected(entity, selectedEnt)) {
         return;
       }
 

--- a/src/admin/ui/rooms/ObjectsSummary.tsx
+++ b/src/admin/ui/rooms/ObjectsSummary.tsx
@@ -22,8 +22,10 @@ const ObjectsSummary = ({ room }: Props) => {
 
   const doorInfos = useSelector(state => doors.map(id => {
     const ent = state.gameState.worldState.doors[id];
-    // TODO: let's force doors to have a name :)
-    return { id, name: ent.closedImg || ent.openImg || ent.id.toString() };
+    return {
+      id,
+      name: ent.name || ent.closedImg || ent.openImg || ent.id.toString(),
+    };
   }));
 
   return (

--- a/src/admin/ui/shared/SaveButton.tsx
+++ b/src/admin/ui/shared/SaveButton.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Button from '@mui/material/Button';
 import useUpload, { UploadState } from '../hooks/useUpload';
+import useCommand from '../hooks/useCommand';
 
 const getCallToAction = (uploadState: UploadState) => {
   switch (uploadState) {
@@ -17,6 +18,7 @@ const getCallToAction = (uploadState: UploadState) => {
 
 const SaveButton = () => {
   const { upload, uploadState } = useUpload('gamedata-draft.json');
+  useCommand('s', upload);
   const callToAction = getCallToAction(uploadState);
 
   return (

--- a/src/admin/ui/shared/Selector.tsx
+++ b/src/admin/ui/shared/Selector.tsx
@@ -29,7 +29,7 @@ const Selector = ({
   return (
     <Box style={{ display: 'flex', flexDirection: 'row' }}>
       <WithTooltip text={tooltip}>
-        <FormControl variant="outlined" style={{ minWidth: 120 }} margin="normal">
+        <FormControl variant="outlined" style={{ minWidth: 140 }} margin="normal">
           <InputLabel>{label}</InputLabel>
           <Select
             value={isEmpty(value) ? '' : value}

--- a/src/game/store/defaults/defaultVerbs.ts
+++ b/src/game/store/defaults/defaultVerbs.ts
@@ -1,39 +1,50 @@
+import { VerbBehavior } from '../types';
+
 const defaultVerbs = [
   {
     name: 'MOVE',
-    defaultText: 'blah',
+    defaultText: '',
+    defaultBehavior: VerbBehavior.MOVE,
   },
   {
     name: 'LOOK',
-    defaultText: 'blah',
+    defaultText: '',
+    defaultBehavior: VerbBehavior.LOOK,
   },
   {
     name: 'OPEN',
-    defaultText: 'blah',
+    defaultText: '',
+    defaultBehavior: VerbBehavior.OPEN,
   },
   {
     name: 'USE',
-    defaultText: 'blah',
+    defaultText: '',
+    defaultBehavior: VerbBehavior.USE,
   },
   {
     name: 'SMOKE',
     defaultText: 'Smoking that would be ill-advised!',
+    defaultBehavior: VerbBehavior.NONE,
   },
   {
     name: 'TAKE',
-    defaultText: 'blah',
+    defaultText: '',
+    defaultBehavior: VerbBehavior.TAKE,
   },
   {
     name: 'HIT',
     defaultText: 'Ya blew it. That really hurt.',
+    defaultBehavior: VerbBehavior.NONE,
   },
   {
     name: 'EAT',
     defaultText: "Don't eat that.",
+    defaultBehavior: VerbBehavior.NONE,
   },
   {
     name: 'SPEAK',
     defaultText: 'No response.',
+    defaultBehavior: VerbBehavior.NONE,
   },
 ];
 

--- a/src/game/store/defaults/getDefaultGameState.ts
+++ b/src/game/store/defaults/getDefaultGameState.ts
@@ -1,4 +1,4 @@
-import { GameState, VerbIndex } from '../types';
+import { GameState } from '../types';
 import defaultVerbs from './defaultVerbs';
 
 type GetDefaultGameState = (friendlyName: string) => GameState;
@@ -9,7 +9,7 @@ const getDefaultGameState: GetDefaultGameState = friendlyName => ({
     rooms: {},
   },
   playerState: {
-    verb: 0 as VerbIndex,
+    verb: 0,
     room: 0,
     page: 0,
     examining: null,

--- a/src/game/store/reducers/selectObjectReducer.ts
+++ b/src/game/store/reducers/selectObjectReducer.ts
@@ -9,7 +9,7 @@ import {
 } from '../types';
 import genericVerbReducer from './verbReducers/genericVerbReducer';
 
-const failLookup: { [key: string]: EntityReducer } = {
+const fallbackLookup: { [key: string]: EntityReducer } = {
   MOVE: moveReducer,
   LOOK: (object: Entity) => withText(object.description),
   OPEN: openReducer,
@@ -23,8 +23,8 @@ const successLookup: { [key: string]: EntityReducer } = {
 
 const getReducer = (verb: VerbIndex, verbs: VerbConfig[]) => {
   const { defaultBehavior, defaultText } = verbs[verb];
-  const failBehavior = failLookup[defaultBehavior] || (() => withText(defaultText));
-  return genericVerbReducer(verb, failBehavior, successLookup[defaultBehavior]);
+  const fallbackBehavior = fallbackLookup[defaultBehavior] || (() => withText(defaultText));
+  return genericVerbReducer(verb, fallbackBehavior, successLookup[defaultBehavior]);
 };
 
 type GenericReducer = (t: 'doors' | 'entities') => ParentReducer<number>;

--- a/src/game/store/reducers/selectObjectReducer.ts
+++ b/src/game/store/reducers/selectObjectReducer.ts
@@ -1,26 +1,31 @@
-import { ParentReducer } from 'shared/util/types';
+import { EntityReducer, ParentReducer } from 'shared/util/types';
 import moveReducer from './verbReducers/moveReducer';
 import openReducer from './verbReducers/openReducer';
 import takeReducer from './verbReducers/takeReducer';
 import _useReducer, { forfeitItemReducer } from './verbReducers/useReducer';
 import { keepState, withText } from './utils';
-import { VerbIndex, VerbConfig } from '../types';
+import {
+  VerbIndex, VerbConfig, Entity,
+} from '../types';
 import genericVerbReducer from './verbReducers/genericVerbReducer';
 
-const getReducer = (verb: VerbIndex, verbs: VerbConfig[]) => ([
-  // TODO: None of these behaviors should be hardcoded. Special behaviors like
-  // MOVE and TAKE should be user-selected in the verb config. In a way,
-  // defaultText is just another special behavior.
-  genericVerbReducer(0, moveReducer),
-  genericVerbReducer(1, object => withText(object.description)),
-  genericVerbReducer(2, openReducer),
-  genericVerbReducer(3, _useReducer, forfeitItemReducer),
-  genericVerbReducer(4, () => withText(verbs[4].defaultText)),
-  genericVerbReducer(5, takeReducer),
-  genericVerbReducer(6, () => withText(verbs[6].defaultText)),
-  genericVerbReducer(7, () => withText(verbs[7].defaultText)),
-  genericVerbReducer(8, () => withText(verbs[8].defaultText)),
-][verb]);
+const failLookup: { [key: string]: EntityReducer } = {
+  MOVE: moveReducer,
+  LOOK: (object: Entity) => withText(object.description),
+  OPEN: openReducer,
+  USE: _useReducer,
+  TAKE: takeReducer,
+};
+
+const successLookup: { [key: string]: EntityReducer } = {
+  USE: forfeitItemReducer,
+};
+
+const getReducer = (verb: VerbIndex, verbs: VerbConfig[]) => {
+  const { defaultBehavior, defaultText } = verbs[verb];
+  const failBehavior = failLookup[defaultBehavior] || (() => withText(defaultText));
+  return genericVerbReducer(verb, failBehavior, successLookup[defaultBehavior]);
+};
 
 type GenericReducer = (t: 'doors' | 'entities') => ParentReducer<number>;
 const selectObjectReducer: GenericReducer = entType => {

--- a/src/game/store/types.ts
+++ b/src/game/store/types.ts
@@ -224,9 +224,19 @@ export interface PlayerState {
 
 export type Flags = string[];
 
+export enum VerbBehavior {
+  NONE = 'NONE',
+  MOVE = 'MOVE',
+  LOOK = 'LOOK',
+  OPEN = 'OPEN',
+  USE = 'USE',
+  TAKE = 'TAKE'
+}
+
 export type VerbConfig = {
   name: string;
-  defaultText: string;
+  defaultText?: string;
+  defaultBehavior: VerbBehavior;
 };
 
 export type ImgConfig = {

--- a/src/game/store/types.ts
+++ b/src/game/store/types.ts
@@ -57,6 +57,7 @@ export interface Music {
 export interface Door {
   type: 'doors';
   id: number;
+  name?: string;
   closedImg?: string;
   openImg?: string;
   position?: Position;

--- a/src/shared/validation/generated/gameStateSchema.js
+++ b/src/shared/validation/generated/gameStateSchema.js
@@ -200,6 +200,9 @@ const gameStateSchema = {
         "id": {
           "type": "number"
         },
+        "name": {
+          "type": "string"
+        },
         "closedImg": {
           "type": "string"
         },

--- a/src/shared/validation/generated/gameStateSchema.js
+++ b/src/shared/validation/generated/gameStateSchema.js
@@ -26,10 +26,13 @@ const gameStateSchema = {
               },
               "defaultText": {
                 "type": "string"
+              },
+              "defaultBehavior": {
+                "$ref": "#/definitions/VerbBehavior"
               }
             },
             "required": [
-              "defaultText",
+              "defaultBehavior",
               "name"
             ]
           }
@@ -962,6 +965,17 @@ const gameStateSchema = {
         "room",
         "verb"
       ]
+    },
+    "VerbBehavior": {
+      "enum": [
+        "LOOK",
+        "MOVE",
+        "NONE",
+        "OPEN",
+        "TAKE",
+        "USE"
+      ],
+      "type": "string"
     }
   },
   "$schema": "http://json-schema.org/draft-07/schema#"


### PR DESCRIPTION
This makes verbs "totally configurable". The specific kinds of behavior like "take" and "move" still involve specific hard-coded logic, but the user can now choose which verbs to attach that logic to (or opt out entirely).

BONUS: now in admin, you can use cmd-s to save

TO TEST:

1. go to http://localhost:3000/admin/test-game/config/ui
2. Click on one of the verb names in the fake UI
3. Try changing the defaultText or defaultBehavior
4. Go play the game and try using the verbs to test the change.

<img width="1790" alt="Screen Shot 2022-07-18 at 11 07 22 PM" src="https://user-images.githubusercontent.com/4368490/179655855-7bfab061-3115-4f67-a563-640ce08ada70.png">

