### PR TITLE
Make managing flags easier

### DIFF
--- a/src/admin/store/reducers/gameStateReducer/flagsReducer.ts
+++ b/src/admin/store/reducers/gameStateReducer/flagsReducer.ts
@@ -1,12 +1,12 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { setGameState } from 'admin/store/sharedActions';
-import { Flags } from 'game/store/types';
+import { Flag } from 'game/store/types';
 
 export const flagsSlice = createSlice({
   name: 'flags',
-  initialState: [] as Flags,
+  initialState: [] as Flag[],
   reducers: {
-    setFlags: (state, action: PayloadAction<Flags>) => {
+    setFlags: (state, action: PayloadAction<Flag[]>) => {
       const flags = action.payload.filter(flag => flag !== '');
       return flags;
     },

--- a/src/admin/ui/config/Flags.tsx
+++ b/src/admin/ui/config/Flags.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
 import { setFlags } from 'admin/store/reducers/gameStateReducer/flagsReducer';
-import { compact, last, uniq } from 'lodash';
+import { compact, uniq } from 'lodash';
 import TextField from '@mui/material/TextField';
 import Autocomplete, { createFilterOptions } from '@mui/material/Autocomplete';
 import { Flag } from 'game/store/types';
@@ -76,11 +76,10 @@ const Flags = () => {
               .includes(inputValue);
 
             if (inputValue !== '' && !isExisting) {
-              // TODO: ensure the flag has no spaces here.
-              // Probably fine to just filter it
+              const newFlag = inputValue.toUpperCase().replaceAll(/\s+/g, '_');
               filtered.push({
-                value: inputValue,
-                label: `Add "${inputValue}"`,
+                value: newFlag,
+                label: `Add "${newFlag}"`,
               });
             }
 

--- a/src/admin/ui/config/Flags.tsx
+++ b/src/admin/ui/config/Flags.tsx
@@ -2,13 +2,35 @@ import React from 'react';
 import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
 import { setFlags } from 'admin/store/reducers/gameStateReducer/flagsReducer';
-import LongTextField from '../shared/LongTextField';
-import { useDispatch, useSelector } from '../hooks/redux';
-import splitString from '../utils/splitString';
+import { compact, uniq } from 'lodash';
+import { Autocomplete, TextField } from '@mui/material';
+import { RootState, useDispatch, useSelector } from '../hooks/redux';
+
+const flagsSelector = (state: RootState) => {
+  const { worldState, flags } = state.gameState;
+  const { entities, doors } = worldState;
+
+  const doorFlags = Object.values(doors)
+    .flatMap(({ openCondition }) => [openCondition]);
+
+  const entityFlags = Object.values(entities)
+    .flatMap(({ visibleFlag, takeableFlag }) => [visibleFlag, takeableFlag]);
+
+  const verbFlags = [...Object.values(entities), ...Object.values(doors)]
+    .flatMap(({ verbs }) => Object.values(verbs || {}).flat())
+    .flatMap(({ addFlags = [], removeFlags = [], prereqFlags = [] }) => [
+      ...addFlags, ...removeFlags, ...prereqFlags,
+    ]);
+
+  const allFlags = compact([...flags, ...doorFlags, ...entityFlags, ...verbFlags]);
+
+  return uniq(allFlags).sort();
+};
 
 const Flags = () => {
   const dispatch = useDispatch();
   const flags = useSelector(state => state.gameState.flags);
+  const allFlags = useSelector(flagsSelector);
 
   return (
     <>
@@ -18,12 +40,21 @@ const Flags = () => {
         </Typography>
       </Grid>
       <Grid item xs={12}>
-        <LongTextField
-          label="initial flags"
-          value={flags.join(',')}
-          onChange={str => {
-            dispatch(setFlags(splitString(str) || []));
-          }}
+        <Autocomplete
+          multiple
+          disableClearable
+          id="tags-outlined"
+          options={allFlags}
+          filterSelectedOptions
+          value={flags}
+          onChange={(e, newFlags) => dispatch(setFlags(newFlags))}
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              label="initial flags"
+              placeholder="add a flag"
+            />
+          )}
         />
       </Grid>
     </>

--- a/src/admin/ui/config/Flags.tsx
+++ b/src/admin/ui/config/Flags.tsx
@@ -2,52 +2,12 @@ import React from 'react';
 import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
 import { setFlags } from 'admin/store/reducers/gameStateReducer/flagsReducer';
-import { compact, uniq } from 'lodash';
-import TextField from '@mui/material/TextField';
-import Autocomplete, { createFilterOptions } from '@mui/material/Autocomplete';
-import { Flag } from 'game/store/types';
-import { RootState, useDispatch, useSelector } from '../hooks/redux';
-
-const filter = createFilterOptions<FlagOption>();
-
-const flagsSelector = (state: RootState) => {
-  const { worldState, flags } = state.gameState;
-  const { entities, doors } = worldState;
-
-  const doorFlags = Object.values(doors)
-    .flatMap(({ openCondition }) => [openCondition]);
-
-  const entityFlags = Object.values(entities)
-    .flatMap(({ visibleFlag, takeableFlag }) => [visibleFlag, takeableFlag]);
-
-  const verbFlags = [...Object.values(entities), ...Object.values(doors)]
-    .flatMap(({ verbs }) => Object.values(verbs || {}).flat())
-    .flatMap(({ addFlags = [], removeFlags = [], prereqFlags = [] }) => [
-      ...addFlags, ...removeFlags, ...prereqFlags,
-    ]);
-
-  const allFlags = compact([...flags, ...doorFlags, ...entityFlags, ...verbFlags]);
-
-  return uniq(allFlags).sort();
-};
-
-const toFlagOption = (flag: Flag) => ({
-  value: flag,
-  label: flag,
-});
-
-type FlagOption = {
-  value: Flag;
-  label: string;
-};
+import { useDispatch, useSelector } from '../hooks/redux';
+import FlagsInput from '../shared/FlagsInput';
 
 const Flags = () => {
   const dispatch = useDispatch();
   const flags = useSelector(state => state.gameState.flags);
-  const allFlags = useSelector(flagsSelector);
-
-  const seedOptions = allFlags.map(toFlagOption);
-  const seedValue = flags.map(toFlagOption);
 
   return (
     <>
@@ -57,43 +17,9 @@ const Flags = () => {
         </Typography>
       </Grid>
       <Grid item xs={12}>
-        <Autocomplete
-          multiple
-          disableClearable
-          id="tags-outlined"
-          options={seedOptions}
-          filterSelectedOptions
-          value={seedValue}
-          onChange={(e, newFlags) => {
-            dispatch(setFlags(newFlags.map(({ value }) => value)));
-          }}
-          filterOptions={(options, params) => {
-            const filtered = filter(options, params);
-
-            const { inputValue } = params;
-            const isExisting = [...options, ...seedValue]
-              .map(({ value }) => value)
-              .includes(inputValue);
-
-            if (inputValue !== '' && !isExisting) {
-              const newFlag = inputValue.toUpperCase().replaceAll(/\s+/g, '_');
-              filtered.push({
-                value: newFlag,
-                label: `Add "${newFlag}"`,
-              });
-            }
-
-            return filtered;
-          }}
-          getOptionLabel={(option) => option.label}
-          isOptionEqualToValue={(a, b) => a.value === b.value}
-          renderInput={(params) => (
-            <TextField
-              {...params}
-              label="initial flags"
-              placeholder="add a flag"
-            />
-          )}
+        <FlagsInput
+          value={flags}
+          onChange={newFlags => dispatch(setFlags(newFlags))}
         />
       </Grid>
     </>

--- a/src/admin/ui/config/Flags.tsx
+++ b/src/admin/ui/config/Flags.tsx
@@ -18,6 +18,7 @@ const Flags = () => {
       </Grid>
       <Grid item xs={12}>
         <FlagsInput
+          label="initial flags"
           value={flags}
           onChange={newFlags => dispatch(setFlags(newFlags))}
         />

--- a/src/admin/ui/config/index.tsx
+++ b/src/admin/ui/config/index.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import Grid from '@mui/material/Grid';
 import Box from '@mui/material/Box';
-import Stack from '@mui/material/Stack';
 import { useParams } from 'react-router-dom';
 import useStyles from '../shared/useStyles';
 import Player from './Player';

--- a/src/admin/ui/rooms/DoorDetails.tsx
+++ b/src/admin/ui/rooms/DoorDetails.tsx
@@ -10,6 +10,7 @@ import ImgSelector from '../shared/assets/ImgSelector';
 import Selector, { makeOptions } from '../shared/Selector';
 import MapPositioner from './MapPositioner';
 import Toggle from '../shared/Toggle';
+import FlagsInput from '../shared/FlagsInput';
 
 type Props = {
   door: Door;
@@ -139,11 +140,12 @@ const DoorDetails = ({ door }: Props) => {
         />
       </Grid>
       <Grid item xs={12}>
-        <LongTextField
+        <FlagsInput
           label="open condition"
           value={door.openCondition}
           onChange={handleChange('openCondition')}
-          tooltip="Custom flag to determine if player can open this door (even if the door is in an OPEN state)"
+          // eslint-disable-next-line max-len
+          // tooltip="Custom flag to determine if player can open this door (even if the door is in an OPEN state)"
         />
       </Grid>
       <Grid item xs={12}>

--- a/src/admin/ui/rooms/ItemDetails.tsx
+++ b/src/admin/ui/rooms/ItemDetails.tsx
@@ -75,8 +75,7 @@ const ItemDetails = ({ item }: Props) => {
           label="takeable flags"
           value={item.takeableFlags}
           onChange={handleChange('takeableFlags')}
-          // eslint-disable-next-line max-len
-          // tooltip="When set, this flag must be on for the player to collect this item (otherwise, the item is takeable by default)"
+          tooltip="When set, all of these flags must be on for the player to collect this item (otherwise, the item is takeable by default)"
         />
       </Grid>
       <Grid item xs={12}>
@@ -84,8 +83,7 @@ const ItemDetails = ({ item }: Props) => {
           label="visible flags"
           value={item.visibleFlags}
           onChange={handleChange('visibleFlags')}
-          // eslint-disable-next-line max-len
-          // tooltip="When set, this flag must be on for this item to be visible (otherwise, the item is visible by default)"
+          tooltip="When set, all of these flags must be on for this item to be visible (otherwise, the item is visible by default)"
         />
       </Grid>
       <Grid item xs={12}>

--- a/src/admin/ui/rooms/ItemDetails.tsx
+++ b/src/admin/ui/rooms/ItemDetails.tsx
@@ -11,6 +11,7 @@ import ImgSelector from '../shared/assets/ImgSelector';
 import Verbs from '../verbs';
 import Toggle from '../shared/Toggle';
 import Selector, { makeOptions } from '../shared/Selector';
+import FlagsInput from '../shared/FlagsInput';
 
 type Props = {
   item: Item;
@@ -70,19 +71,21 @@ const ItemDetails = ({ item }: Props) => {
         />
       </Grid>
       <Grid item xs={12}>
-        <LongTextField
-          label="takeable flag"
-          value={item.takeableFlag}
-          onChange={handleChange('takeableFlag')}
-          tooltip="When set, this flag must be on for the player to collect this item (otherwise, the item is takeable by default)"
+        <FlagsInput
+          label="takeable flags"
+          value={item.takeableFlags}
+          onChange={handleChange('takeableFlags')}
+          // eslint-disable-next-line max-len
+          // tooltip="When set, this flag must be on for the player to collect this item (otherwise, the item is takeable by default)"
         />
       </Grid>
       <Grid item xs={12}>
-        <LongTextField
-          label="visible flag"
-          value={item.visibleFlag}
-          onChange={handleChange('visibleFlag')}
-          tooltip="When set, this flag must be on for this item to be visible (otherwise, the item is visible by default)"
+        <FlagsInput
+          label="visible flags"
+          value={item.visibleFlags}
+          onChange={handleChange('visibleFlags')}
+          // eslint-disable-next-line max-len
+          // tooltip="When set, this flag must be on for this item to be visible (otherwise, the item is visible by default)"
         />
       </Grid>
       <Grid item xs={12}>

--- a/src/admin/ui/rooms/SceneryDetails.tsx
+++ b/src/admin/ui/rooms/SceneryDetails.tsx
@@ -109,8 +109,7 @@ const SceneryDetails = ({ scenery }: Props) => {
           label="visible flags"
           value={scenery.visibleFlags}
           onChange={handleChange('visibleFlags')}
-          // eslint-disable-next-line max-len
-          // tooltip="When set, this flag must be on for this scenery to be visible (otherwise, the item is visible by default)"
+          tooltip="When set, all of these flags must be on for this scenery to be visible (otherwise, the item is visible by default)"
         />
       </Grid>
       <Contains container={scenery} />

--- a/src/admin/ui/rooms/SceneryDetails.tsx
+++ b/src/admin/ui/rooms/SceneryDetails.tsx
@@ -12,6 +12,7 @@ import Selector from '../shared/Selector';
 import Verbs from '../verbs';
 import Contains from './Contains';
 import Toggle from '../shared/Toggle';
+import FlagsInput from '../shared/FlagsInput';
 
 type Props = {
   scenery: Scenery;
@@ -23,7 +24,7 @@ const SceneryDetails = ({ scenery }: Props) => {
   const sceneriesEditing = useSelector(state => state.editorState.sceneryEditing);
   const positionEditing = sceneriesEditing[scenery.id] || 'startPosition';
 
-  const handleChange = (fieldName: keyof Scenery) => (value: Nullable<string>) => {
+  const handleChange = (fieldName: keyof Scenery) => (value: Nullable<string> | string[]) => {
     dispatch(setEntity({
       id: scenery.id,
       entity: {
@@ -104,11 +105,12 @@ const SceneryDetails = ({ scenery }: Props) => {
         />
       </Grid>
       <Grid item xs={12}>
-        <LongTextField
-          label="visible flag"
-          value={scenery.visibleFlag}
-          onChange={handleChange('visibleFlag')}
-          tooltip="When set, this flag must be on for this scenery to be visible (otherwise, the item is visible by default)"
+        <FlagsInput
+          label="visible flags"
+          value={scenery.visibleFlags}
+          onChange={handleChange('visibleFlags')}
+          // eslint-disable-next-line max-len
+          // tooltip="When set, this flag must be on for this scenery to be visible (otherwise, the item is visible by default)"
         />
       </Grid>
       <Contains container={scenery} />

--- a/src/admin/ui/shared/FlagsInput.tsx
+++ b/src/admin/ui/shared/FlagsInput.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { compact, uniq } from 'lodash';
+import TextField from '@mui/material/TextField';
+import Autocomplete, { createFilterOptions } from '@mui/material/Autocomplete';
+import { Flag } from 'game/store/types';
+import { RootState, useSelector } from '../hooks/redux';
+
+const filter = createFilterOptions<FlagOption>();
+
+const flagsSelector = (state: RootState) => {
+  const { worldState, flags } = state.gameState;
+  const { entities, doors } = worldState;
+
+  const doorFlags = Object.values(doors)
+    .flatMap(({ openCondition }) => [openCondition]);
+
+  const entityFlags = Object.values(entities)
+    .flatMap(({ visibleFlag, takeableFlag }) => [visibleFlag, takeableFlag]);
+
+  const verbFlags = [...Object.values(entities), ...Object.values(doors)]
+    .flatMap(({ verbs }) => Object.values(verbs || {}).flat())
+    .flatMap(({ addFlags = [], removeFlags = [], prereqFlags = [] }) => [
+      ...addFlags, ...removeFlags, ...prereqFlags,
+    ]);
+
+  const allFlags = compact([...flags, ...doorFlags, ...entityFlags, ...verbFlags]);
+
+  return uniq(allFlags).sort();
+};
+
+const toFlagOption = (flag: Flag) => ({
+  value: flag,
+  label: flag,
+});
+
+type FlagOption = {
+  value: Flag;
+  label: string;
+};
+
+type Props = {
+  value: Flag[];
+  onChange: (f: Flag[]) => void;
+};
+
+const FlagsInput = (props: Props) => {
+  const allFlags = useSelector(flagsSelector);
+  const seedOptions = allFlags.map(toFlagOption);
+  const seedValue = props.value.map(toFlagOption);
+
+  return (
+    <Autocomplete
+      multiple
+      disableClearable
+      options={seedOptions}
+      filterSelectedOptions
+      value={seedValue}
+      onChange={(e, newFlags) => {
+        props.onChange(newFlags.map(({ value }) => value));
+      }}
+      filterOptions={(options, params) => {
+        const filtered = filter(options, params);
+
+        const { inputValue } = params;
+        const isExisting = [...options, ...seedValue]
+          .map(({ value }) => value)
+          .includes(inputValue);
+
+        if (inputValue !== '' && !isExisting) {
+          const newFlag = inputValue.toUpperCase().replaceAll(/\s+/g, '_');
+          filtered.push({
+            value: newFlag,
+            label: `Add "${newFlag}"`,
+          });
+        }
+
+        return filtered;
+      }}
+      getOptionLabel={(option) => option.label}
+      isOptionEqualToValue={(a, b) => a.value === b.value}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          placeholder="add a flag"
+        />
+      )}
+    />
+  );
+};
+
+export default FlagsInput;

--- a/src/admin/ui/shared/FlagsInput.tsx
+++ b/src/admin/ui/shared/FlagsInput.tsx
@@ -4,6 +4,7 @@ import TextField from '@mui/material/TextField';
 import Autocomplete, { createFilterOptions } from '@mui/material/Autocomplete';
 import { Flag } from 'game/store/types';
 import { RootState, useSelector } from '../hooks/redux';
+import WithTooltip from './WithTooltip';
 
 const filter = createFilterOptions<FlagOption>();
 
@@ -42,53 +43,58 @@ type Props = {
   value?: Flag[];
   onChange: (f: Flag[]) => void;
   label: string;
+  tooltip?: string;
 };
 
 const FlagsInput = (props: Props) => {
-  const { value: propsValue = [], onChange, label } = props;
+  const {
+    value: propsValue = [], onChange, label, tooltip,
+  } = props;
   const allFlags = useSelector(flagsSelector);
   const seedOptions = allFlags.map(toFlagOption);
   const seedValue = propsValue.map(toFlagOption);
 
   return (
-    <Autocomplete
-      sx={{ mt: 2, mb: 2 }}
-      multiple
-      disableClearable
-      options={seedOptions}
-      filterSelectedOptions
-      value={seedValue}
-      onChange={(e, newFlags) => {
-        onChange(newFlags.map(({ value }) => value));
-      }}
-      filterOptions={(options, params) => {
-        const filtered = filter(options, params);
+    <WithTooltip text={tooltip}>
+      <Autocomplete
+        sx={{ mt: 2, mb: 2 }}
+        multiple
+        disableClearable
+        options={seedOptions}
+        filterSelectedOptions
+        value={seedValue}
+        onChange={(e, newFlags) => {
+          onChange(newFlags.map(({ value }) => value));
+        }}
+        filterOptions={(options, params) => {
+          const filtered = filter(options, params);
 
-        const { inputValue } = params;
-        const isExisting = [...options, ...seedValue]
-          .map(({ value }) => value)
-          .includes(inputValue);
+          const { inputValue } = params;
+          const isExisting = [...options, ...seedValue]
+            .map(({ value }) => value)
+            .includes(inputValue);
 
-        if (inputValue !== '' && !isExisting) {
-          const newFlag = inputValue.toUpperCase().replaceAll(/\s+/g, '_');
-          filtered.push({
-            value: newFlag,
-            label: `Add "${newFlag}"`,
-          });
-        }
+          if (inputValue !== '' && !isExisting) {
+            const newFlag = inputValue.toUpperCase().replaceAll(/\s+/g, '_');
+            filtered.push({
+              value: newFlag,
+              label: `Add "${newFlag}"`,
+            });
+          }
 
-        return filtered;
-      }}
-      getOptionLabel={(option) => option.label}
-      isOptionEqualToValue={(a, b) => a.value === b.value}
-      renderInput={(params) => (
-        <TextField
-          {...params}
-          label={label}
-          placeholder="choose a flag"
-        />
-      )}
-    />
+          return filtered;
+        }}
+        getOptionLabel={(option) => option.label}
+        isOptionEqualToValue={(a, b) => a.value === b.value}
+        renderInput={(params) => (
+          <TextField
+            {...params}
+            label={label}
+            placeholder="choose a flag"
+          />
+        )}
+      />
+    </WithTooltip>
   );
 };
 

--- a/src/admin/ui/shared/FlagsInput.tsx
+++ b/src/admin/ui/shared/FlagsInput.tsx
@@ -12,10 +12,10 @@ const flagsSelector = (state: RootState) => {
   const { entities, doors } = worldState;
 
   const doorFlags = Object.values(doors)
-    .flatMap(({ openCondition }) => [openCondition]);
+    .flatMap(({ openCondition }) => openCondition);
 
   const entityFlags = Object.values(entities)
-    .flatMap(({ visibleFlag, takeableFlag }) => [visibleFlag, takeableFlag]);
+    .flatMap(({ visibleFlags = [], takeableFlags = [] }) => [...visibleFlags, ...takeableFlags]);
 
   const verbFlags = [...Object.values(entities), ...Object.values(doors)]
     .flatMap(({ verbs }) => Object.values(verbs || {}).flat())

--- a/src/admin/ui/shared/FlagsInput.tsx
+++ b/src/admin/ui/shared/FlagsInput.tsx
@@ -39,24 +39,27 @@ type FlagOption = {
 };
 
 type Props = {
-  value: Flag[];
+  value?: Flag[];
   onChange: (f: Flag[]) => void;
+  label: string;
 };
 
 const FlagsInput = (props: Props) => {
+  const { value: propsValue = [], onChange, label } = props;
   const allFlags = useSelector(flagsSelector);
   const seedOptions = allFlags.map(toFlagOption);
-  const seedValue = props.value.map(toFlagOption);
+  const seedValue = propsValue.map(toFlagOption);
 
   return (
     <Autocomplete
+      sx={{ mt: 2, mb: 2 }}
       multiple
       disableClearable
       options={seedOptions}
       filterSelectedOptions
       value={seedValue}
       onChange={(e, newFlags) => {
-        props.onChange(newFlags.map(({ value }) => value));
+        onChange(newFlags.map(({ value }) => value));
       }}
       filterOptions={(options, params) => {
         const filtered = filter(options, params);
@@ -81,7 +84,8 @@ const FlagsInput = (props: Props) => {
       renderInput={(params) => (
         <TextField
           {...params}
-          placeholder="add a flag"
+          label={label}
+          placeholder="choose a flag"
         />
       )}
     />

--- a/src/admin/ui/verbs/Verb.tsx
+++ b/src/admin/ui/verbs/Verb.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { DoorDir, VerbLogic } from 'game/store/types';
 import {
-  Box, Button, Card, CardContent, Typography,
+  Box, Button, Card, CardContent, Stack, Typography,
 } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import LongTextField from '../shared/LongTextField';
@@ -49,49 +49,56 @@ const Verb = ({
           {' '}
           {index + 1}
         </Typography>
-        <LongTextField
-          label="text"
-          value={verb.text}
-          onChange={onChange('text')}
-        />
-        <Selector
-          label="move to"
-          value={verb.moveTo}
-          onChange={val => onChange('moveTo')(val ? parseInt(val, 10) : undefined)}
-          options={makeOptions(allRoomIds)}
-        />
-        <Selector
-          label="animation direction"
-          value={verb.moveDir}
-          onChange={onChange('moveDir')}
-          options={makeOptions(Object.keys(DoorDir))}
-        />
-        <FlagsInput
-          label="add flags"
-          value={verb.addFlags}
-          onChange={newFlags => onChange('addFlags')(newFlags)}
-        />
-        <FlagsInput
-          label="remove flags"
-          value={verb.removeFlags}
-          onChange={newFlags => onChange('removeFlags')(newFlags)}
-        />
-        <FlagsInput
-          label="prereq flags"
-          value={verb.prereqFlags}
-          onChange={newFlags => onChange('prereqFlags')(newFlags)}
-        />
-        <Selector
-          label="prereq using"
-          value={verb.prereqUsing}
-          onChange={val => onChange('prereqUsing')(parseInt(val, 10))}
-          options={makeOptions(allEntityIds)}
-          style={{ width: '150px' }}
-        />
-        <Condition
-          condition={verb.condition}
-          onChange={onChange('condition')}
-        />
+        <Stack direction="column">
+          <LongTextField
+            label="text"
+            value={verb.text}
+            onChange={onChange('text')}
+            tooltip="Text to display when this verb condition is met"
+          />
+          <Selector
+            label="move to"
+            value={verb.moveTo}
+            onChange={val => onChange('moveTo')(val ? parseInt(val, 10) : undefined)}
+            options={makeOptions(allRoomIds)}
+          />
+          <Selector
+            label="animation direction"
+            value={verb.moveDir}
+            onChange={onChange('moveDir')}
+            options={makeOptions(Object.keys(DoorDir))}
+          />
+          <FlagsInput
+            label="add flags"
+            value={verb.addFlags}
+            onChange={newFlags => onChange('addFlags')(newFlags)}
+            tooltip="Flags that get added when this verb is triggered"
+          />
+          <FlagsInput
+            label="remove flags"
+            value={verb.removeFlags}
+            onChange={newFlags => onChange('removeFlags')(newFlags)}
+            tooltip="Flags that get removed when this verb is triggered"
+          />
+          <FlagsInput
+            label="prereq flags"
+            value={verb.prereqFlags}
+            onChange={newFlags => onChange('prereqFlags')(newFlags)}
+            tooltip="Flags that must be set for this verb to be triggered"
+          />
+          <Selector
+            label="prereq using"
+            value={verb.prereqUsing}
+            onChange={val => onChange('prereqUsing')(parseInt(val, 10))}
+            options={makeOptions(allEntityIds)}
+            style={{ width: '150px' }}
+            tooltip="ID of the item the player must be USING to trigger this verb"
+          />
+          <Condition
+            condition={verb.condition}
+            onChange={onChange('condition')}
+          />
+        </Stack>
         <Box>
           <Button onClick={() => handleDelete(index)} color="error">
             Delete

--- a/src/admin/ui/verbs/Verb.tsx
+++ b/src/admin/ui/verbs/Verb.tsx
@@ -7,7 +7,6 @@ import { makeStyles } from '@mui/styles';
 import LongTextField from '../shared/LongTextField';
 import Selector, { makeOptions } from '../shared/Selector';
 import { useSelector } from '../hooks/redux';
-import splitString from '../utils/splitString';
 import Condition from './Condition';
 import FlagsInput from '../shared/FlagsInput';
 

--- a/src/admin/ui/verbs/Verb.tsx
+++ b/src/admin/ui/verbs/Verb.tsx
@@ -9,6 +9,7 @@ import Selector, { makeOptions } from '../shared/Selector';
 import { useSelector } from '../hooks/redux';
 import splitString from '../utils/splitString';
 import Condition from './Condition';
+import FlagsInput from '../shared/FlagsInput';
 
 const useStyles = makeStyles({
   verbCard: {
@@ -66,20 +67,20 @@ const Verb = ({
           onChange={onChange('moveDir')}
           options={makeOptions(Object.keys(DoorDir))}
         />
-        <LongTextField
+        <FlagsInput
           label="add flags"
-          value={(verb.addFlags || []).join(',')}
-          onChange={str => onChange('addFlags')(splitString(str))}
+          value={verb.addFlags}
+          onChange={newFlags => onChange('addFlags')(newFlags)}
         />
-        <LongTextField
+        <FlagsInput
           label="remove flags"
-          value={(verb.removeFlags || []).join(',')}
-          onChange={str => onChange('removeFlags')(splitString(str))}
+          value={verb.removeFlags}
+          onChange={newFlags => onChange('removeFlags')(newFlags)}
         />
-        <LongTextField
+        <FlagsInput
           label="prereq flags"
-          value={(verb.prereqFlags || []).join(',')}
-          onChange={str => onChange('prereqFlags')(splitString(str))}
+          value={verb.prereqFlags}
+          onChange={newFlags => onChange('prereqFlags')(newFlags)}
         />
         <Selector
           label="prereq using"

--- a/src/game/store/reducers/rootReducer.ts
+++ b/src/game/store/reducers/rootReducer.ts
@@ -8,7 +8,7 @@ import changePageReducer from './changePageReducer';
 import roomReducer from './roomReducer';
 import { setValue, clearValue } from './utils';
 import {
-  Flags, GameStoreState, PlayerState, WorldState,
+  Flag, GameStoreState, PlayerState, WorldState,
   Menu, VerbIndex, Nullable, PageDir, Music, Config,
 } from '../types';
 import defaultState from '../defaults/defaultGameStoreState';
@@ -24,7 +24,7 @@ type ActionTypes = {
   SET_STATE: GameStoreState;
   SET_WORLD_STATE: WorldState;
   SET_PLAYER_STATE: PlayerState;
-  SET_FLAGS: Flags;
+  SET_FLAGS: Flag[];
   SET_CONFIG: Config;
   SET_TEXT: Nullable<string[]>;
   SET_NEXT_MUSIC: Music;
@@ -69,7 +69,7 @@ const applyReducer = <
 const setState: ParentReducer<GameStoreState> = payload => () => payload;
 const setWorldState: ParentReducer<WorldState> = setValue('worldState');
 const setPlayerState: ParentReducer<PlayerState> = setValue('playerState');
-const setFlags: ParentReducer<Flags> = setValue('flags');
+const setFlags: ParentReducer<Flag[]> = setValue('flags');
 const setConfig: ParentReducer<Config> = setValue('config');
 const setText: ParentReducer<Nullable<string[]>> = setValue('text');
 const setRoom: ParentReducer<number> = roomReducer;

--- a/src/game/store/reducers/verbReducers/genericVerbReducer.ts
+++ b/src/game/store/reducers/verbReducers/genericVerbReducer.ts
@@ -1,6 +1,6 @@
 import { compose } from 'redux';
 import {
-  Entity, Flags, Nullable, VerbIndex, VerbLogic,
+  Entity, Flag, Nullable, VerbIndex, VerbLogic,
 } from 'game/store/types';
 import { EntityReducer } from 'shared/util/types';
 import get from 'shared/util/get';
@@ -10,7 +10,7 @@ import {
 } from '../utils';
 import effectsReducer from '../effectsReducer';
 
-const isValid = (verbLogic: VerbLogic, object: Entity, using: Nullable<number>, flags: Flags) => {
+const isValid = (verbLogic: VerbLogic, object: Entity, using: Nullable<number>, flags: Flag[]) => {
   const { prereqUsing, prereqFlags } = verbLogic;
   if (prereqUsing && prereqUsing !== using) {
     return false;
@@ -31,7 +31,7 @@ type GetVerbLogic = (
   object: Entity,
   verb: VerbIndex,
   using: Nullable<number>,
-  flags: Flags
+  flags: Flag[]
 ) => Nullable<VerbLogic>;
 const getVerbLogic: GetVerbLogic = (object, verb, using, flags) => {
   const options = get(object, `verbs.${verb}`);

--- a/src/game/store/reducers/verbReducers/openReducer.ts
+++ b/src/game/store/reducers/verbReducers/openReducer.ts
@@ -1,11 +1,11 @@
 import { compose } from 'redux';
 import { EntityReducer } from 'shared/util/types';
 import {
-  Door, DoorState, Flags, Scenery,
+  Door, DoorState, Flag, Scenery,
 } from 'game/store/types';
 import { withText, setValue, keepState } from '../utils';
 
-const doorReducer = (door: Door, flags: Flags) => {
+const doorReducer = (door: Door, flags: Flag[]) => {
   switch (door.state) {
     case DoorState.CLOSED:
       if (!door.openCondition || flags.includes(door.openCondition)) {

--- a/src/game/store/reducers/verbReducers/openReducer.ts
+++ b/src/game/store/reducers/verbReducers/openReducer.ts
@@ -3,12 +3,13 @@ import { EntityReducer } from 'shared/util/types';
 import {
   Door, DoorState, Flag, Scenery,
 } from 'game/store/types';
+import includesAll from 'shared/util/includesAll';
 import { withText, setValue, keepState } from '../utils';
 
 const doorReducer = (door: Door, flags: Flag[]) => {
   switch (door.state) {
     case DoorState.CLOSED:
-      if (!door.openCondition || flags.includes(door.openCondition)) {
+      if (includesAll(flags, door.openCondition)) {
         return compose(
           withText(door.openText),
           setValue(`worldState.doors[${door.id}].state`)(DoorState.OPEN),

--- a/src/game/store/reducers/verbReducers/takeReducer.ts
+++ b/src/game/store/reducers/verbReducers/takeReducer.ts
@@ -1,4 +1,5 @@
 import { compose } from 'redux';
+import includesAll from 'shared/util/includesAll';
 import { EntityReducer, ItemReducer } from 'shared/util/types';
 import { withText, updateValue, filterValues } from '../utils';
 
@@ -12,7 +13,7 @@ const itemReducer: ItemReducer = (item, playerState) => {
 
 const takeReducer: EntityReducer = (object, playerState, flags) => {
   if (object.type === 'items') {
-    if (object.takeableFlag && !flags.includes(object.takeableFlag)) {
+    if (object.takeableFlags?.length && !includesAll(flags, object.takeableFlags)) {
       return withText(`No good. Taking ${object.name} isn't working`);
     }
     return itemReducer(object, playerState, flags);

--- a/src/game/store/types.ts
+++ b/src/game/store/types.ts
@@ -23,6 +23,7 @@ export enum DoorDir {
 export type PageDir = 'UP' | 'DOWN';
 export type Menu = 'NONE' | 'MAIN' | 'GAME_OVER';
 export type EntityType = 'items' | 'scenery' | 'doors';
+export type Flag = string;
 
 export type Nullable<T> = T | null | undefined;
 
@@ -72,7 +73,7 @@ export interface Door {
   openText?: string;
   keyId?: number;
   hidden?: boolean;
-  openCondition?: string;
+  openCondition?: Flag;
   // TODO: Somehow make the shared fields between entities more explicit
   verbs?: VerbMappings;
 }
@@ -108,9 +109,9 @@ export interface VerbLogic {
   text?: string;
   moveTo?: number;
   moveDir?: DoorDir;
-  addFlags?: string[];
-  removeFlags?: string[];
-  prereqFlags?: string[];
+  addFlags?: Flag[];
+  removeFlags?: Flag[];
+  prereqFlags?: Flag[];
   prereqUsing?: number;
   effects?: Effect[];
   condition?: Condition;
@@ -160,8 +161,8 @@ export interface Item {
   imgSet?: ImgSet;
   // TODO: see if this can use genericVerbReducer
   onTake?: string;
-  takeableFlag?: string;
-  visibleFlag?: string;
+  takeableFlag?: Flag;
+  visibleFlag?: Flag;
   requiresPrecision?: boolean;
   verbs?: VerbMappings;
   contains: Nullable<number[]>;
@@ -191,7 +192,8 @@ export interface Scenery {
   contains: Nullable<number[]>;
   trigger?: VerbIndex;
   movedText?: string;
-  visibleFlag?: string;
+  takeableFlag?: Flag;
+  visibleFlag?: Flag;
   isStatic?: boolean;
   time?: number;
   timeEffect?: TimeEffect;
@@ -223,7 +225,7 @@ export interface PlayerState {
   page: number;
 }
 
-export type Flags = string[];
+export type Flags = Flag[];
 
 export enum VerbBehavior {
   NONE = 'NONE',

--- a/src/game/store/types.ts
+++ b/src/game/store/types.ts
@@ -73,7 +73,7 @@ export interface Door {
   openText?: string;
   keyId?: number;
   hidden?: boolean;
-  openCondition?: Flag;
+  openCondition?: Flag[];
   // TODO: Somehow make the shared fields between entities more explicit
   verbs?: VerbMappings;
 }
@@ -161,8 +161,8 @@ export interface Item {
   imgSet?: ImgSet;
   // TODO: see if this can use genericVerbReducer
   onTake?: string;
-  takeableFlag?: Flag;
-  visibleFlag?: Flag;
+  takeableFlags?: Flag[];
+  visibleFlags?: Flag[];
   requiresPrecision?: boolean;
   verbs?: VerbMappings;
   contains: Nullable<number[]>;
@@ -192,8 +192,8 @@ export interface Scenery {
   contains: Nullable<number[]>;
   trigger?: VerbIndex;
   movedText?: string;
-  takeableFlag?: Flag;
-  visibleFlag?: Flag;
+  takeableFlags?: Flag[];
+  visibleFlags?: Flag[];
   isStatic?: boolean;
   time?: number;
   timeEffect?: TimeEffect;

--- a/src/game/store/types.ts
+++ b/src/game/store/types.ts
@@ -225,8 +225,6 @@ export interface PlayerState {
   page: number;
 }
 
-export type Flags = Flag[];
-
 export enum VerbBehavior {
   NONE = 'NONE',
   MOVE = 'MOVE',
@@ -282,7 +280,7 @@ export type Config = {
 export interface GameState {
   worldState: WorldState;
   playerState: PlayerState;
-  flags: Flags;
+  flags: Flag[];
   config: Config;
 }
 

--- a/src/game/ui/viewport/viewportSelector.ts
+++ b/src/game/ui/viewport/viewportSelector.ts
@@ -1,6 +1,7 @@
 import {
   GameStoreState, WorldState,
 } from 'game/store/types';
+import includesAll from 'shared/util/includesAll';
 
 type Populate = <
   T extends 'entities' | 'doors' // TODO: do a better job here
@@ -25,7 +26,7 @@ const viewportSelector = (state: GameStoreState) => {
     doors: doors.map(populate(worldState, 'doors'))
       .filter(door => !!(door.openImg || door.closedImg)),
     entities: entities
-      .filter(entity => !entity.visibleFlag || flags.includes(entity.visibleFlag)),
+      .filter(({ visibleFlags }) => includesAll(flags, visibleFlags)),
     roomImg: images.get(img || ''),
     video,
     gameName,

--- a/src/shared/util/includesAll.ts
+++ b/src/shared/util/includesAll.ts
@@ -1,0 +1,5 @@
+const includesAll = (bigger: string[], smaller: string[] = []) => {
+  return !smaller.some(item => !bigger.includes(item));
+};
+
+export default includesAll;

--- a/src/shared/util/types.ts
+++ b/src/shared/util/types.ts
@@ -1,7 +1,7 @@
 import {
   Door,
   Entity,
-  Flags,
+  Flag,
   GameStoreState,
   Item,
   Nullable,
@@ -20,7 +20,7 @@ export type Transformer<T> = (arg: T) => T;
 export type StateTransformer = Transformer<GameStoreState>;
 
 type ChildReducer<T> = {
-  (ent: T, playerState: PlayerState, flags: Flags): StateTransformer;
+  (ent: T, playerState: PlayerState, flags: Flag[]): StateTransformer;
 };
 
 export type EntityReducer = ChildReducer<Entity>;
@@ -31,7 +31,7 @@ export type DoorReducer = ChildReducer<Door>;
 export type ParentReducer<PayloadType> = {
   // TODO: group verb names and flags together
   // eslint-disable-next-line max-len
-  (p: PayloadType, ps: PlayerState, w: WorldState, f: Flags, verbNames: VerbConfig[]): StateTransformer;
+  (p: PayloadType, ps: PlayerState, w: WorldState, f: Flag[], verbNames: VerbConfig[]): StateTransformer;
 };
 
 export type EmptyReducer = () => StateTransformer;

--- a/src/shared/validation/generated/gameStateSchema.js
+++ b/src/shared/validation/generated/gameStateSchema.js
@@ -246,7 +246,10 @@ const gameStateSchema = {
           "type": "boolean"
         },
         "openCondition": {
-          "type": "string"
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "verbs": {
           "type": "object",
@@ -546,11 +549,17 @@ const gameStateSchema = {
         "onTake": {
           "type": "string"
         },
-        "takeableFlag": {
-          "type": "string"
+        "takeableFlags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
-        "visibleFlag": {
-          "type": "string"
+        "visibleFlags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "requiresPrecision": {
           "type": "boolean"
@@ -843,11 +852,17 @@ const gameStateSchema = {
         "movedText": {
           "type": "string"
         },
-        "takeableFlag": {
-          "type": "string"
+        "takeableFlags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
-        "visibleFlag": {
-          "type": "string"
+        "visibleFlags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "isStatic": {
           "type": "boolean"

--- a/src/shared/validation/generated/gameStateSchema.js
+++ b/src/shared/validation/generated/gameStateSchema.js
@@ -843,6 +843,9 @@ const gameStateSchema = {
         "movedText": {
           "type": "string"
         },
+        "takeableFlag": {
+          "type": "string"
+        },
         "visibleFlag": {
           "type": "string"
         },


### PR DESCRIPTION
This makes adding and removing flags more intuitive in the UI. The input automatically finds any existing flags in the game that match what you've typed, and you can create new ones on the spot.

NOTE: At this point I decided it made sense to make all flag inputs support multiple flags. It makes the code a tiny bit simpler and there's no real benefit to restricting it to one.

I've updated all the flag inputs, but here's an example screenshot:
<img width="608" alt="Screen Shot 2022-07-23 at 2 03 30 PM" src="https://user-images.githubusercontent.com/4368490/180617548-66cd1c08-666d-4d37-af62-6da698fd5caf.png">