### PR TITLE
make the "self" button work

### DIFF
--- a/src/admin/store/reducers/editorStateReducer/index.ts
+++ b/src/admin/store/reducers/editorStateReducer/index.ts
@@ -2,9 +2,11 @@ import { combineReducers } from 'redux';
 import selectedEntityReducer from './selectedEntityReducer';
 import sceneryEditingReducer from './sceneryEditingReducer';
 import tooltipsReducer from './tooltipsReducer';
+import miscInfoReducer from './miscInfoReducer';
 
 export default combineReducers({
   selectedEntity: selectedEntityReducer,
   sceneryEditing: sceneryEditingReducer,
   tooltips: tooltipsReducer,
+  miscInfo: miscInfoReducer,
 });

--- a/src/admin/store/reducers/editorStateReducer/miscInfoReducer.ts
+++ b/src/admin/store/reducers/editorStateReducer/miscInfoReducer.ts
@@ -1,0 +1,20 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { Nullable } from 'game/store/types';
+import { setSelected } from './selectedEntityReducer';
+
+export type MiscInfo = string;
+
+export const miscInfoSlice = createSlice({
+  name: 'miscInfo',
+  initialState: null as Nullable<MiscInfo>,
+  reducers: {
+    setMiscInfo: (state, action: PayloadAction<MiscInfo>) => action.payload,
+  },
+  extraReducers: builder => {
+    builder.addCase(setSelected, () => null);
+  },
+});
+
+export const { setMiscInfo } = miscInfoSlice.actions;
+
+export default miscInfoSlice.reducer;

--- a/src/admin/store/reducers/editorStateReducer/selectedEntityReducer.ts
+++ b/src/admin/store/reducers/editorStateReducer/selectedEntityReducer.ts
@@ -1,5 +1,6 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { Nullable } from 'game/store/types';
+import { setMiscInfo } from './miscInfoReducer';
 
 export type SelectedEntity = {
   id: number;
@@ -12,6 +13,9 @@ export const selectedEntitySlice = createSlice({
   reducers: {
     setSelected: (state, action: PayloadAction<SelectedEntity>) => action.payload,
     clearSelected: () => null,
+  },
+  extraReducers: builder => {
+    builder.addCase(setMiscInfo, () => null);
   },
 });
 

--- a/src/admin/store/reducers/gameStateReducer/worldStateReducer/entitiesReducer.ts
+++ b/src/admin/store/reducers/gameStateReducer/worldStateReducer/entitiesReducer.ts
@@ -58,6 +58,7 @@ const createItem = (state: Lookup<Item | Scenery>, id: number, isStatic: boolean
       top: 0,
     },
     isStatic,
+    contains: [],
   };
 };
 
@@ -67,13 +68,13 @@ const createScenery = (state: Lookup<Item | Scenery>, id: number) => {
     type: 'scenery',
     name: 'New Scenery',
     description: '',
-    contains: null,
     // TODO: don't set position for items that don't render in viewport
     startPosition: {
       left: 0,
       top: 0,
     },
     size: defaultSize,
+    contains: [],
   };
 };
 

--- a/src/admin/store/reducers/gameStateReducer/worldStateReducer/entitiesReducer.ts
+++ b/src/admin/store/reducers/gameStateReducer/worldStateReducer/entitiesReducer.ts
@@ -52,7 +52,6 @@ const createItem = (state: Lookup<Item | Scenery>, id: number, isStatic: boolean
     type: 'items',
     name: 'New Item',
     description: '',
-    contains: null,
     // TODO: don't set position for items that don't render in viewport
     position: {
       left: 0,

--- a/src/admin/ui/config/gameLayout/MenuButtonWidget.tsx
+++ b/src/admin/ui/config/gameLayout/MenuButtonWidget.tsx
@@ -29,7 +29,6 @@ const MenuButtonWidget = (props: Props) => {
   } = props;
   const images = useSelector(state => state.images);
   const canvases = useSelector(canvasesSelector);
-  const [hovering, setHovering] = useState(false);
 
   const textLeft = hasButton ? 9 : 0;
   const textTop = hasButton ? 1 : 0;
@@ -43,34 +42,11 @@ const MenuButtonWidget = (props: Props) => {
       draggable
       onClick={onClick}
       onDragEnd={onDrag}
-      onMouseEnter={e => {
-        setHovering(true);
-        setCursorStyle('pointer')(e);
-      }}
-      onMouseLeave={e => {
-        setHovering(false);
-        setCursorStyle('default')(e);
-      }}
+      onMouseEnter={setCursorStyle('pointer')}
+      onMouseLeave={setCursorStyle('default')}
     >
       {hasButton && <Image image={images['menu-button']} />}
       {text && <Text text={text} left={textLeft} top={textTop} canvases={canvases} />}
-      {hovering && (
-        // https://konvajs.org/api/Konva.Text.html
-        // But maybe what we really want is helper text that shows up somewhere else on the screen
-        // Downside of that is we need to dispatch and keep it in the store
-        // But that's not that big of a deal
-        <KonvaText
-          text="hi"
-          fontSize={8}
-          x={3}
-          y={-4}
-          fill="white"
-          shadowColor="black"
-          shadowOffsetX={1}
-          shadowOffsetY={1}
-
-        />
-      )}
     </Group>
   );
 };

--- a/src/admin/ui/config/gameLayout/MenuButtonWidget.tsx
+++ b/src/admin/ui/config/gameLayout/MenuButtonWidget.tsx
@@ -1,8 +1,8 @@
 import { useSelector } from 'admin/ui/hooks/redux';
 import { TextStateless as Text, makeCanvasSet } from 'game/ui/shared/Text';
 import { KonvaEventObject } from 'konva/types/Node';
-import React from 'react';
-import { Group, Image } from 'react-konva';
+import React, { useState } from 'react';
+import { Group, Image, Text as KonvaText } from 'react-konva';
 import { createSelector } from 'reselect';
 import { setCursorStyle } from 'shared/components/PreciseImage';
 
@@ -29,6 +29,7 @@ const MenuButtonWidget = (props: Props) => {
   } = props;
   const images = useSelector(state => state.images);
   const canvases = useSelector(canvasesSelector);
+  const [hovering, setHovering] = useState(false);
 
   const textLeft = hasButton ? 9 : 0;
   const textTop = hasButton ? 1 : 0;
@@ -42,11 +43,34 @@ const MenuButtonWidget = (props: Props) => {
       draggable
       onClick={onClick}
       onDragEnd={onDrag}
-      onMouseEnter={setCursorStyle('pointer')}
-      onMouseLeave={setCursorStyle('default')}
+      onMouseEnter={e => {
+        setHovering(true);
+        setCursorStyle('pointer')(e);
+      }}
+      onMouseLeave={e => {
+        setHovering(false);
+        setCursorStyle('default')(e);
+      }}
     >
       {hasButton && <Image image={images['menu-button']} />}
       {text && <Text text={text} left={textLeft} top={textTop} canvases={canvases} />}
+      {hovering && (
+        // https://konvajs.org/api/Konva.Text.html
+        // But maybe what we really want is helper text that shows up somewhere else on the screen
+        // Downside of that is we need to dispatch and keep it in the store
+        // But that's not that big of a deal
+        <KonvaText
+          text="hi"
+          fontSize={8}
+          x={3}
+          y={-4}
+          fill="white"
+          shadowColor="black"
+          shadowOffsetX={1}
+          shadowOffsetY={1}
+
+        />
+      )}
     </Group>
   );
 };

--- a/src/admin/ui/config/gameLayout/MenuButtonWidget.tsx
+++ b/src/admin/ui/config/gameLayout/MenuButtonWidget.tsx
@@ -19,15 +19,19 @@ type Props = {
   top: number;
   left: number;
   text?: string;
+  hasButton: boolean;
   onClick?: () => void;
   onDrag?: (e: KonvaEventObject<DragEvent>) => void;
 };
 const MenuButtonWidget = (props: Props) => {
   const {
-    top, left, text, onClick = () => {}, onDrag = () => {},
+    top, left, text, hasButton, onClick = () => {}, onDrag = () => {},
   } = props;
   const images = useSelector(state => state.images);
   const canvases = useSelector(canvasesSelector);
+
+  const textLeft = hasButton ? 9 : 0;
+  const textTop = hasButton ? 1 : 0;
 
   return (
     <Group
@@ -41,8 +45,8 @@ const MenuButtonWidget = (props: Props) => {
       onMouseEnter={setCursorStyle('pointer')}
       onMouseLeave={setCursorStyle('default')}
     >
-      <Image image={images['menu-button']} />
-      {text && <Text text={text} left={9} top={1} canvases={canvases} />}
+      {hasButton && <Image image={images['menu-button']} />}
+      {text && <Text text={text} left={textLeft} top={textTop} canvases={canvases} />}
     </Group>
   );
 };

--- a/src/admin/ui/config/gameLayout/MenuButtonsUI.tsx
+++ b/src/admin/ui/config/gameLayout/MenuButtonsUI.tsx
@@ -14,6 +14,13 @@ const texts = {
   save: 'save',
 };
 
+const hasButton = {
+  pageUp: true,
+  pageDown: true,
+  self: false,
+  save: true,
+};
+
 const MenuButtonsUI = () => {
   const dispatch = useDispatch();
   const positions = useSelector(state => state.gameState.present.config.positions);
@@ -31,6 +38,7 @@ const MenuButtonsUI = () => {
           top={positions[name].top}
           left={positions[name].left}
           text={texts[name]}
+          hasButton={hasButton[name]}
           onDrag={(e: KonvaEventObject<DragEvent>) => {
             dispatch(setMenuButtonPosition({
               top: Math.round(e.target.y()),

--- a/src/admin/ui/config/gameLayout/MenuButtonsUI.tsx
+++ b/src/admin/ui/config/gameLayout/MenuButtonsUI.tsx
@@ -1,3 +1,4 @@
+import { setMiscInfo } from 'admin/store/reducers/editorStateReducer/miscInfoReducer';
 import { setMenuButtonPosition } from 'admin/store/reducers/gameStateReducer/configReducer/positionsReducer';
 import { useSelector, useDispatch } from 'admin/ui/hooks/redux';
 import { KonvaEventObject } from 'konva/types/Node';
@@ -19,6 +20,13 @@ const hasButton = {
   pageDown: true,
   self: false,
   save: true,
+};
+
+const helperTexts = {
+  pageUp: 'pageUp button',
+  pageDown: 'pageDown button',
+  self: 'self, just the text',
+  save: 'save button and text',
 };
 
 const MenuButtonsUI = () => {
@@ -45,6 +53,9 @@ const MenuButtonsUI = () => {
               left: Math.round(e.target.x()),
               name,
             }));
+          }}
+          onClick={() => {
+            dispatch(setMiscInfo(`${helperTexts[name]} (drag to reposition)`));
           }}
         />
       ))}

--- a/src/admin/ui/config/gameLayout/MiniMapUI.tsx
+++ b/src/admin/ui/config/gameLayout/MiniMapUI.tsx
@@ -1,3 +1,4 @@
+import { setMiscInfo } from 'admin/store/reducers/editorStateReducer/miscInfoReducer';
 import { setMenuButtonPosition } from 'admin/store/reducers/gameStateReducer/configReducer/positionsReducer';
 import { useSelector, useDispatch } from 'admin/ui/hooks/redux';
 import { KonvaEventObject } from 'konva/types/Node';
@@ -30,6 +31,7 @@ const MiniMapPositioned = ({ top, left }: Props) => {
           name: 'miniMap',
         }));
       }}
+      onClick={() => dispatch(setMiscInfo('miniMap (drag to reposition)'))}
     >
       {dummyPositions.map(({ x, y }) => (
         <Image

--- a/src/admin/ui/config/gameLayout/MiscInfo.tsx
+++ b/src/admin/ui/config/gameLayout/MiscInfo.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { useSelector } from 'admin/ui/hooks/redux';
+import { Stack, Typography } from '@mui/material';
+
+const MiscInfo = () => {
+  const miscInfo = useSelector(state => state.editorState.miscInfo);
+
+  if (!miscInfo) {
+    return null;
+  }
+
+  return (
+    <Stack direction="column">
+      <Typography variant="h6">
+        {miscInfo}
+      </Typography>
+    </Stack>
+  );
+};
+
+export default MiscInfo;

--- a/src/admin/ui/config/gameLayout/VerbsUI.tsx
+++ b/src/admin/ui/config/gameLayout/VerbsUI.tsx
@@ -21,6 +21,7 @@ const Verb = (props: Props) => {
       left={left}
       top={top}
       text={verbs[index].name}
+      hasButton
       onClick={() => dispatch(setSelected({
         id: index,
         type: 'verbs',

--- a/src/admin/ui/config/gameLayout/index.tsx
+++ b/src/admin/ui/config/gameLayout/index.tsx
@@ -11,6 +11,7 @@ import ImgSelector from '../../shared/assets/ImgSelector';
 import GameLayoutWidget from './GameLayoutWidget';
 import VerbDetails from './VerbDetails';
 import StaticEntityList from './StaticEntityList';
+import MiscInfo from './MiscInfo';
 
 const useStyles = makeStyles({
   leftColumn: {
@@ -95,6 +96,7 @@ const GameLayout = () => {
       <Box className={styles.leftColumn}>
         <EntityDetails />
         <VerbDetails />
+        <MiscInfo />
       </Box>
     </>
   );

--- a/src/admin/ui/verbs/Verb.tsx
+++ b/src/admin/ui/verbs/Verb.tsx
@@ -30,8 +30,8 @@ const Verb = ({
 }: Props) => {
   const styles = useStyles();
   const allRoomIds = useSelector(state => Object.keys(state.gameState.present.worldState.rooms));
-  const allEntityIds = useSelector(state => {
-    return Object.keys(state.gameState.present.worldState.entities);
+  const allEntities = useSelector(state => {
+    return Object.values(state.gameState.present.worldState.entities);
   });
 
   const onChange = (fieldName: keyof VerbLogic) => (value: any) => {
@@ -92,7 +92,10 @@ const Verb = ({
             label="prereq using"
             value={verb.prereqUsing}
             onChange={val => onChange('prereqUsing')(parseInt(val, 10))}
-            options={makeOptions(allEntityIds)}
+            options={allEntities.map(({ id, name }) => ({
+              value: id,
+              label: [id, name].filter(Boolean).join(': '),
+            }))}
             style={{ width: '150px' }}
             tooltip="ID of the item the player must be USING to trigger this verb"
           />

--- a/src/game/store/defaults/getDefaultGameState.ts
+++ b/src/game/store/defaults/getDefaultGameState.ts
@@ -17,6 +17,7 @@ const getDefaultGameState: GetDefaultGameState = friendlyName => ({
         description: 'You look great!',
         id: 0,
         type: 'items',
+        contains: [],
       },
     },
     rooms: {},

--- a/src/game/store/defaults/getDefaultGameState.ts
+++ b/src/game/store/defaults/getDefaultGameState.ts
@@ -5,7 +5,20 @@ type GetDefaultGameState = (friendlyName: string) => GameState;
 const getDefaultGameState: GetDefaultGameState = friendlyName => ({
   worldState: {
     doors: {},
-    entities: {},
+    entities: {
+      0: {
+        name: 'self',
+        isStatic: true,
+        position: { left: 191, top: 199 },
+        img: 'menu-button',
+        verbs: {
+          0: [{ text: 'Move yourself? Nope.' }],
+        },
+        description: 'You look great!',
+        id: 0,
+        type: 'items',
+      },
+    },
     rooms: {},
   },
   playerState: {

--- a/src/game/store/reducers/utils.ts
+++ b/src/game/store/reducers/utils.ts
@@ -57,6 +57,5 @@ export const when = (pred: boolean) => (transform: StateTransformer) => {
 export const filterValues = <
   PathType extends NumberArrayPath
 >(path: PathType) => (id: Nullable<number>) => updateValue<NumberArrayPath>(path)(objects => {
-  if (!objects) return null;
   return filter(objects, objectId => objectId !== id);
 });

--- a/src/game/store/types.ts
+++ b/src/game/store/types.ts
@@ -165,7 +165,7 @@ export interface Item {
   visibleFlags?: Flag[];
   requiresPrecision?: boolean;
   verbs?: VerbMappings;
-  contains: Nullable<number[]>;
+  contains?: number[];
   isStatic?: boolean;
   time?: number;
   timeEffect?: TimeEffect;

--- a/src/game/store/types.ts
+++ b/src/game/store/types.ts
@@ -165,7 +165,7 @@ export interface Item {
   visibleFlags?: Flag[];
   requiresPrecision?: boolean;
   verbs?: VerbMappings;
-  contains?: number[];
+  contains: number[];
   isStatic?: boolean;
   time?: number;
   timeEffect?: TimeEffect;
@@ -189,7 +189,7 @@ export interface Scenery {
   img?: string;
   openText?: string;
   verbs?: VerbMappings;
-  contains: Nullable<number[]>;
+  contains: number[];
   trigger?: VerbIndex;
   movedText?: string;
   takeableFlags?: Flag[];

--- a/src/game/ui/menu/MenuButtons.tsx
+++ b/src/game/ui/menu/MenuButtons.tsx
@@ -2,6 +2,7 @@ import { PageDir } from 'game/store/types';
 import React from 'react';
 import { Image } from 'shared/components/tappables';
 import { useSelector } from 'shared/hooks/redux';
+import Text from '../shared/Text';
 import MenuOption from './MenuOption';
 
 type Props = {
@@ -28,10 +29,9 @@ const MenuRight = ({ onPageClick, onSaveClick }: Props) => {
         onClick={() => onPageClick('DOWN')}
         image={images.get('menu-button')}
       />
-      <MenuOption
+      <Text
         left={self.left}
         top={self.top}
-        onClick={() => {}}
         text="self"
       />
       <MenuOption

--- a/src/shared/util/types.ts
+++ b/src/shared/util/types.ts
@@ -67,7 +67,7 @@ type GetNullables<Base, Prefix extends string = '', AnyNumber = 0> = {
 export type ValidPathsFor<Root, Constraint> =
   Exclude<ConstrainedTypes<Root, Constraint>, undefined>;
 
-export type NumberArrayPath = ValidPathsFor<GameStoreState, Nullable<number[]>>;
+export type NumberArrayPath = ValidPathsFor<GameStoreState, number[]>;
 export type NumberPath = ValidPathsFor<GameStoreState, number>;
 export type NullablePath = Exclude<GetNullables<GameStoreState>, undefined>;
 

--- a/src/shared/validation/generated/gameStateSchema.js
+++ b/src/shared/validation/generated/gameStateSchema.js
@@ -624,17 +624,10 @@ const gameStateSchema = {
           }
         },
         "contains": {
-          "anyOf": [
-            {
-              "type": "array",
-              "items": {
-                "type": "number"
-              }
-            },
-            {
-              "type": "null"
-            }
-          ]
+          "type": "array",
+          "items": {
+            "type": "number"
+          }
         },
         "isStatic": {
           "type": "boolean"

--- a/src/shared/validation/generated/gameStateSchema.js
+++ b/src/shared/validation/generated/gameStateSchema.js
@@ -649,6 +649,7 @@ const gameStateSchema = {
         }
       },
       "required": [
+        "contains",
         "description",
         "id",
         "name",
@@ -816,17 +817,10 @@ const gameStateSchema = {
           }
         },
         "contains": {
-          "anyOf": [
-            {
-              "type": "array",
-              "items": {
-                "type": "number"
-              }
-            },
-            {
-              "type": "null"
-            }
-          ]
+          "type": "array",
+          "items": {
+            "type": "number"
+          }
         },
         "trigger": {
           "enum": [
@@ -868,6 +862,7 @@ const gameStateSchema = {
         }
       },
       "required": [
+        "contains",
         "id",
         "startPosition",
         "type"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
+    "strictNullChecks": true,
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
This creates a default item in new games called "self" that corresponds to the menu option (see screenshot). Previously this was unimplemented. I made this an item rather than a special case for flexibility. Games can have multiple non-verb options like this in the menu.

<img width="1231" alt="Screen Shot 2022-07-24 at 11 59 02 PM" src="https://user-images.githubusercontent.com/4368490/180696244-9c25725a-b01e-4608-9709-8c41a1a50d26.png">

TODO:
- [x] Remove the menu-button from the self text in the UI editor because it's confusing now (so the text and the button are moved separately, I guess)
- [x] update SELF in the game code as well to just be static text (since the button is now an "item")
- [x] Make it a little clearer (maybe with tooltips, not sure) which buttons you're moving around in the UI editor (like self, page up and page down)
